### PR TITLE
Small enchancement to generate_pdf

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -68,7 +68,7 @@ class Document(BaseLaTeXContainer):
         command = 'pdflatex --jobname="' + self.filename + '" "' + \
             self.filename + '.tex"'
 
-        subprocess.call(command, shell=True)
+        subprocess.check_call(command, shell=True)
 
         if clean:
             subprocess.call('rm "' + self.filename + '.aux" "' +


### PR DESCRIPTION
Small enchancement to generate_pdf, now invalid latex compilation
results in raised exception, which simplifies launching pylatex in
batch mode (or from ipython notebook).
