### PR TITLE
Added extrapreamble option

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -21,7 +21,7 @@ class Document(BaseLaTeXContainer):
 
     def __init__(self, filename='default_filename', documentclass='article',
                  fontenc='T1', inputenc='utf8', author=None, title=None,
-                 date=None, data=None):
+                 date=None, data=None, extrapreamble=None):
         self.filename = filename
 
         self.documentclass = documentclass
@@ -36,6 +36,8 @@ class Document(BaseLaTeXContainer):
             packages.append(Package(author, base='author'))
         if date is not None:
             packages.append(Package(date, base='date'))
+
+        self.extrapreamble = extrapreamble
 
         super().__init__(data, packages=packages)
 
@@ -52,6 +54,9 @@ class Document(BaseLaTeXContainer):
         head = r'\documentclass{' + self.documentclass + '}'
 
         head += self.dumps_packages()
+
+        if self.extrapreamble is not None:
+            head += self.extrapreamble + '\n'
 
         return head + document
 


### PR DESCRIPTION
Hello,

this is a proposal in order to add extra text to the preamble. In my case, I need to add several instruccions in the preamble. Here is an example how this works:

```
from pylatex import Document
preamble = r'\setlength\parindent{0pt}'
doc = Document(extrapreamble=preamble)
doc.generate_tex()
```

Then, the output in `default_filename.tex` is:

```
\documentclass{article}\usepackage[T1]{fontenc}

\usepackage[utf8]{inputenc}

\usepackage{lmodern}
\setlength\parindent{0pt}
\begin{document}\end{document}
```

I'm open to suggestions.

Felipe
