### PR TITLE
Use context manager to ensure file is always closed

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -67,9 +67,8 @@ class Document(BaseLaTeXContainer):
 
     def generate_tex(self):
         """Generates a .tex file."""
-        newf = open(self.filename + '.tex', 'w')
-        self.dump(newf)
-        newf.close()
+        with open(self.filename + '.tex', 'w') as newf:
+            self.dump(newf)
 
     def generate_pdf(self, clean=True):
         """Generates a pdf"""


### PR DESCRIPTION
The current code worked but this change prevents accidentally removing the `.close()` call and not having the file closed. It'll also continue to work in case exceptions happen.