### PR TITLE
Remove the filename attribute

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -18,22 +18,22 @@ def fill_document(doc):
 
 if __name__ == '__main__':
     # Basic document
-    doc = Document()
+    doc = Document('basic')
     fill_document(doc)
     
-    doc.generate_pdf("basic")
-    doc.generate_tex("basic")
-    
-    # Add stuff to the document
-    doc.append(Section('A second section'))
-    doc.append('Some text.')
-    
-    doc.generate_pdf("basic2")
-    tex = doc.dumps() # The document as string in LaTeX syntax
+    doc.generate_pdf()
+    doc.generate_tex()
     
     # Document with `\maketitle` command activated
     doc = Document(author='Author', date='01/01/01', title='Title', 
                    maketitle=True)
     fill_document(doc)
     
-    doc.generate_pdf("basic_maketitle", clean=False)
+    doc.generate_pdf('basic_maketitle', clean=False)
+    
+    # Add stuff to the document
+    doc.append(Section('A second section'))
+    doc.append('Some text.')
+    
+    doc.generate_pdf('basic_maketitle2')
+    tex = doc.dumps() # The document as string in LaTeX syntax

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 from pylatex import Document, Section, Subsection
 from pylatex.utils import italic, escape_latex
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,39 @@
+from pylatex import Document, Section, Subsection
+from pylatex.utils import italic, escape_latex
+
+
+
+def fill_document(doc):
+    """Adds a section, a subsection and some text to the document.
+    
+        :param doc: the document
+        :type doc: :class:`pylatex.Document` instance
+    """
+    with doc.create(Section('A section')):
+        doc.append('Some regular text and some ' + italic('italic text. '))
+        
+        with doc.create(Subsection('A subsection')):
+            doc.append(escape_latex('Also some crazy characters: $&#{}'))
+
+
+if __name__ == '__main__':
+    # Basic document
+    doc = Document()
+    fill_document(doc)
+    
+    doc.generate_pdf("basic")
+    doc.generate_tex("basic")
+    
+    # Add stuff to the document
+    doc.append(Section('A second section'))
+    doc.append('Some text.')
+    
+    doc.generate_pdf("basic2")
+    tex = doc.dumps() # The document as string in LaTeX syntax
+    
+    # Document with `\maketitle` command activated
+    doc = Document(author='Author', date='01/01/01', title='Title', 
+                   maketitle=True)
+    fill_document(doc)
+    
+    doc.generate_pdf("basic_maketitle", clean=False)

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -25,8 +25,8 @@ class Document(BaseLaTeXContainer):
     """
 
     def __init__(self, filename='default_filename', documentclass='article',
-                 fontenc='T1', inputenc='utf8', author=None, title=None,
-                 date=None, data=None, maketitle=False):
+                 fontenc='T1', inputenc='utf8', author='', title='',
+                 date='', data=None, maketitle=False):
         self.filename = filename
         self.maketitle = maketitle
 
@@ -43,12 +43,9 @@ class Document(BaseLaTeXContainer):
 
         self.preamble = []
 
-        if title is not None:
-            self.preamble.append(Command('title', title))
-        if author is not None:
-            self.preamble.append(Command('author', author))
-        if date is not None:
-            self.preamble.append(Command('date', date))
+        self.preamble.append(Command('title', title))
+        self.preamble.append(Command('author', author))
+        self.preamble.append(Command('date', date))
 
         super().__init__(data, packages=packages)
 

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -24,9 +24,11 @@ class Document(BaseLaTeXContainer):
     stuff to the preamble or the packages.
     """
 
-    def __init__(self, documentclass='article', fontenc='T1', inputenc='utf8', 
+    def __init__(self, default_filename='default_filename', 
+                 documentclass='article', fontenc='T1', inputenc='utf8', 
                  author='', title='', date='', data=None, maketitle=False):
         """
+            :param default_filename: the default filename to save files
             :param documentclass: the LaTeX class of the document
             :param fontenc: the option for the fontenc package
             :param inputenc: the option for the inputenc package
@@ -36,7 +38,7 @@ class Document(BaseLaTeXContainer):
             :param data: 
             :param maketitle: whether `\maketitle` command is activated or not.
             
-            :type filename: str
+            :type default_filename: str
             :type documentclass: str or :class:`command.Command` instance
             :type fontenc: str
             :type inputenc: str
@@ -46,6 +48,7 @@ class Document(BaseLaTeXContainer):
             :type data: list
             :type maketitle: bool
         """
+        self.default_filename = default_filename
         self.maketitle = maketitle
 
         if isinstance(documentclass, Command):
@@ -87,17 +90,19 @@ class Document(BaseLaTeXContainer):
 
         return head + os.linesep + document
 
-    def generate_tex(self, filename):
+    def generate_tex(self, filename=''):
         """Generates a .tex file.
         
             :param filename: the name of the file
         
             :type filename: str
         """
+        filename = self.select_filename(filename)
+        
         with open(filename + '.tex', 'w') as newf:
             self.dump(newf)
 
-    def generate_pdf(self, filename, clean=True):
+    def generate_pdf(self, filename='', clean=True):
         """Generates a .pdf file.
             
             :param filename: the name of the file
@@ -107,6 +112,8 @@ class Document(BaseLaTeXContainer):
             :type filename: str
             :type clean: bool
         """
+        filename = self.select_filename(filename)
+        
         self.generate_tex(filename)
 
         command = 'pdflatex --jobname="' + filename + '" "' + filename + '.tex"'
@@ -118,3 +125,18 @@ class Document(BaseLaTeXContainer):
             subprocess.call('rm "' + filename + '.log"', shell=True)
             subprocess.call('rm "' + filename + '.tex"', shell=True)
             subprocess.call('rm "' + filename + '.out"', shell=True)
+            
+    def select_filename(self, filename):
+        """Makes a choice between `filename` and `self.default_filename`.
+        
+            :param filename: the filename to be compared with 
+            `self.default_filename`
+        
+            :type filename: str
+            
+            :rtype: str
+        """
+        if filename == '':
+            return self.default_filename
+        else:
+            return filename

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -20,14 +20,33 @@ from .base_classes import BaseLaTeXContainer
 class Document(BaseLaTeXContainer):
 
     """
-    A class that contains a full latex document. If needed, you can append
-    stuff to the preamble or the packages if needed.
+    A class that contains a full LaTeX document. If needed, you can append
+    stuff to the preamble or the packages.
     """
 
-    def __init__(self, filename='default_filename', documentclass='article',
-                 fontenc='T1', inputenc='utf8', author='', title='',
-                 date='', data=None, maketitle=False):
-        self.filename = filename
+    def __init__(self, documentclass='article', fontenc='T1', inputenc='utf8', 
+                 author='', title='', date='', data=None, maketitle=False):
+        """
+            :param filename: the filename used to save the document
+            :param documentclass: the LaTeX class of the document
+            :param fontenc: the option for the fontenc package
+            :param inputenc: the option for the inputenc package
+            :param author: the author of the document
+            :param title: the title of the document
+            :param date: the date of the document
+            :param data: 
+            :param maketitle: whether `\maketitle` command is added or not.
+            
+            :type filename: str
+            :type documentclass: str or :class:`command.Command` instance
+            :type fontenc: str
+            :type inputenc: str
+            :type author: str
+            :type title: str
+            :type date: str
+            :type data: list
+            :type maketitle: bool
+        """
         self.maketitle = maketitle
 
         if isinstance(documentclass, Command):
@@ -50,7 +69,10 @@ class Document(BaseLaTeXContainer):
         super().__init__(data, packages=packages)
 
     def dumps(self):
-        """Represents the document as a string in LaTeX syntax."""
+        """Represents the document as a string in LaTeX syntax.
+        
+            :rtype: str
+        """
         document = r'\begin{document}' + os.linesep
 
         if self.maketitle:
@@ -66,22 +88,34 @@ class Document(BaseLaTeXContainer):
 
         return head + os.linesep + document
 
-    def generate_tex(self):
-        """Generates a .tex file."""
-        with open(self.filename + '.tex', 'w') as newf:
+    def generate_tex(self, filename):
+        """Generates a .tex file.
+        
+            :param filename: the name of the file
+        
+            :type filename: str
+        """
+        with open(filename + '.tex', 'w') as newf:
             self.dump(newf)
 
-    def generate_pdf(self, clean=True):
-        """Generates a pdf"""
+    def generate_pdf(self, filename, clean=True):
+        """Generates a .pdf file.
+            
+            :param filename: the name of the file
+            :param clean: whether non-pdf files created by `pdflatex` must be 
+            removed or not
+            
+            :type filename: str
+            :type clean: bool
+        """
         self.generate_tex()
 
-        command = 'pdflatex --jobname="' + self.filename + '" "' + \
-            self.filename + '.tex"'
+        command = 'pdflatex --jobname="' + filename + '" "' + filename + '.tex"'
 
         subprocess.check_call(command, shell=True)
 
         if clean:
-            subprocess.call('rm "' + self.filename + '.aux" "' +
-                            self.filename + '.out" "' +
-                            self.filename + '.log" "' +
-                            self.filename + '.tex"', shell=True)
+            subprocess.call('rm "' + filename + '.aux" "' +
+                            filename + '.out" "' +
+                            filename + '.log" "' +
+                            filename + '.tex"', shell=True)

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -27,7 +27,6 @@ class Document(BaseLaTeXContainer):
     def __init__(self, documentclass='article', fontenc='T1', inputenc='utf8', 
                  author='', title='', date='', data=None, maketitle=False):
         """
-            :param filename: the filename used to save the document
             :param documentclass: the LaTeX class of the document
             :param fontenc: the option for the fontenc package
             :param inputenc: the option for the inputenc package
@@ -35,7 +34,7 @@ class Document(BaseLaTeXContainer):
             :param title: the title of the document
             :param date: the date of the document
             :param data: 
-            :param maketitle: whether `\maketitle` command is added or not.
+            :param maketitle: whether `\maketitle` command is activated or not.
             
             :type filename: str
             :type documentclass: str or :class:`command.Command` instance
@@ -108,14 +107,14 @@ class Document(BaseLaTeXContainer):
             :type filename: str
             :type clean: bool
         """
-        self.generate_tex()
+        self.generate_tex(filename)
 
         command = 'pdflatex --jobname="' + filename + '" "' + filename + '.tex"'
 
         subprocess.check_call(command, shell=True)
 
         if clean:
-            subprocess.call('rm "' + filename + '.aux" "' +
-                            filename + '.out" "' +
-                            filename + '.log" "' +
-                            filename + '.tex"', shell=True)
+            subprocess.call('rm "' + filename + '.aux"', shell=True)
+            subprocess.call('rm "' + filename + '.log"', shell=True)
+            subprocess.call('rm "' + filename + '.tex"', shell=True)
+            subprocess.call('rm "' + filename + '.out"', shell=True)

--- a/tests/multirow_test.py
+++ b/tests/multirow_test.py
@@ -2,7 +2,7 @@
 
 from pylatex import Document, Section, Subsection, Table
 
-doc = Document(filename="multirow")
+doc = Document(default_filename="multirow")
 section = Section('Multirow Test')
 
 test1 = Subsection('Multicol')

--- a/tests/multirow_test_cm.py
+++ b/tests/multirow_test_cm.py
@@ -2,7 +2,7 @@
 
 from pylatex import Document, Section, Subsection, Table
 
-doc = Document(filename="multirow")
+doc = Document(default_filename="multirow")
 
 with doc.create(Section('Multirow Test')):
     with doc.create(Subsection('Multicol')):


### PR DESCRIPTION
Specifying a filename in `generate_pdf` and `generate_tex` methods appears to be more flexible, as the `basic.py` example shows. If this change is approved, I'll update the other examples.

Moreover, the .out file does not always exist so it made the pdf generation crash.