### PR TITLE
Sean list enhancement

### DIFF
--- a/examples/lists_example.py
+++ b/examples/lists_example.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Test for list structures in PyLaTeX.
+# More info @ http://en.wikibooks.org/wiki/LaTeX/List_Structures
+
+from pylatex import Document, Section, Itemize, Enumerate, Description
+
+
+doc = Document()
+
+# create a bulleted "itemize" list like the below:
+# \begin{itemize}
+#   \item The first item
+#   \item The second item
+#   \item The third etc \ldots
+# \end{itemize}
+
+with doc.create(Section('"Itemize" list')):
+    with doc.create(Itemize()) as itemize:
+        itemize.add_item("the first item")
+        itemize.add_item("the second item")
+        itemize.add_item("the third etc")
+        itemize.append("\\ldots")  # you can append to existing items
+
+# create a numbered "enumerate" list like the below:
+# \begin{enumerate}
+#   \item The first item
+#   \item The second item
+#   \item The third etc \ldots
+# \end{enumerate}
+
+with doc.create(Section('"Enumerate" list')):
+    with doc.create(Enumerate()) as enum:
+        enum.add_item("the first item")
+        enum.add_item("the second item")
+        enum.add_item("the third etc \\ldots")
+
+# create a labelled "description" list like the below:
+# \begin{description}
+#   \item[First] The first item
+#   \item[Second] The second item
+#   \item[Third] The third etc \ldots
+# \end{description}
+
+with doc.create(Section('"Description" list')):
+    with doc.create(Description()) as desc:
+        desc.add_item("First", "The first item")
+        desc.add_item("Second", "The second item")
+        desc.add_item("Third", "The third etc \\ldots")
+
+doc.generate_pdf()

--- a/examples/lists_example.py
+++ b/examples/lists_example.py
@@ -17,11 +17,18 @@ doc = Document()
 # \end{itemize}
 
 with doc.create(Section('"Itemize" list')):
+<<<<<<< HEAD
     with doc.create(Itemize()) as itemize:
         itemize.add_item("the first item")
         itemize.add_item("the second item")
         itemize.add_item("the third etc")
         itemize.append("\\ldots")  # you can append to existing items
+=======
+    with doc.create(Itemize()) as enum:
+        enum.add_item("the first item")
+        enum.add_item("the second item")
+        enum.add_item("the third etc \\ldots")
+>>>>>>> 15f72299515a28204d91fdce896d642add07a383
 
 # create a numbered "enumerate" list like the below:
 # \begin{enumerate}
@@ -44,9 +51,16 @@ with doc.create(Section('"Enumerate" list')):
 # \end{description}
 
 with doc.create(Section('"Description" list')):
+<<<<<<< HEAD
     with doc.create(Description()) as desc:
         desc.add_item("First", "The first item")
         desc.add_item("Second", "The second item")
         desc.add_item("Third", "The third etc \\ldots")
+=======
+    with doc.create(Description()) as enum:
+        enum.add_item("First", "The first item")
+        enum.add_item("Second", "The second item")
+        enum.add_item("Third", "The third etc \\ldots")
+>>>>>>> 15f72299515a28204d91fdce896d642add07a383
 
 doc.generate_pdf()

--- a/pylatex/__init__.py
+++ b/pylatex/__init__.py
@@ -16,3 +16,4 @@ from .section import Section, Subsection, Subsubsection  # noqa
 from .table import Table  # noqa
 from .pgfplots import TikZ, Axis, Plot  # noqa
 from .graphics import Figure, Plt  # noqa
+from .lists import Enumerate, Itemize, Description  # noqa

--- a/pylatex/lists.py
+++ b/pylatex/lists.py
@@ -13,6 +13,25 @@
 from .base_classes import BaseLaTeXNamedContainer
 
 
+<<<<<<< HEAD
+=======
+def Item(s, label=None):
+    u"""Returns the string itemized.
+
+        :param s:
+
+        :type s: str
+
+        :return:
+        :rtype: str
+    """
+    if label:
+        return r'\item[' + label + ']{' + s + '}'
+
+    return r'\item{' + s + '}'
+
+
+>>>>>>> 15f72299515a28204d91fdce896d642add07a383
 class List(BaseLaTeXNamedContainer):
 
     """A class that represents a list."""
@@ -33,6 +52,7 @@ class List(BaseLaTeXNamedContainer):
         super().__init__(list_type, data=data, options=pos,
                          argument=list_spec, **kwargs)
 
+<<<<<<< HEAD
     def _item(self, label=None):
         """ Begin an item block. """
         if label:
@@ -49,6 +69,16 @@ class List(BaseLaTeXNamedContainer):
         """
         self.append(self._item())
         self.append(s)
+=======
+    def add_item(self, item):
+        """ Adds an item to the list.
+
+            :param item:
+
+            :type item: string
+        """
+        self.append(Item(item))
+>>>>>>> 15f72299515a28204d91fdce896d642add07a383
 
 
 class Enumerate(List):
@@ -75,6 +105,7 @@ class Description(List):
         super(Description, self).__init__(*args, list_type='description',
                                           **kwargs)
 
+<<<<<<< HEAD
     def add_item(self, label, s):
         """ Adds an item to the list.
 
@@ -86,3 +117,15 @@ class Description(List):
         """
         self.append(self._item(label))
         self.append(s)
+=======
+    def add_item(self, label, item):
+        """ Adds an item to the list.
+
+            :param label:
+            :param item:
+
+            :type label: string
+            :type item: string
+        """
+        self.append(Item(item, label))
+>>>>>>> 15f72299515a28204d91fdce896d642add07a383

--- a/pylatex/lists.py
+++ b/pylatex/lists.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+    pylatex.lists
+    ~~~~~~~
+
+    This module implements the class that deals with latex List objects
+    specifically Enumerate and Itemize.
+
+    :copyright: (c) 2015 by Sean McLemon.
+    :license: MIT, see License for more details.
+"""
+
+from .base_classes import BaseLaTeXNamedContainer
+
+
+class List(BaseLaTeXNamedContainer):
+
+    """A class that represents a list."""
+
+    def __init__(self, list_spec=None, data=None, pos=None,
+                 list_type="enumerate", **kwargs):
+        """
+            :param list_spec:
+            :param list_type:
+            :param data:
+            :param pos:
+
+            :type list_spec: str
+            :type list_type: str
+            :type data: list
+            :type pos: list
+        """
+        super().__init__(list_type, data=data, options=pos,
+                         argument=list_spec, **kwargs)
+
+    def _item(self, label=None):
+        """ Begin an item block. """
+        if label:
+            return r'\item[' + label + '] '
+
+        return r'\item '
+
+    def add_item(self, s):
+        """ Adds an item to the list.
+
+            :param s:
+
+            :type s: string
+        """
+        self.append(self._item())
+        self.append(s)
+
+
+class Enumerate(List):
+
+    """ A class that represents an enumerate list """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, list_type='enumerate', **kwargs)
+
+
+class Itemize(List):
+
+    """ A class that represents an itemize list """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, list_type='itemize', **kwargs)
+
+
+class Description(List):
+
+    """ A class that represents a description list """
+
+    def __init__(self, *args, **kwargs):
+        super(Description, self).__init__(*args, list_type='description',
+                                          **kwargs)
+
+    def add_item(self, label, s):
+        """ Adds an item to the list.
+
+            :param label:
+            :param s:
+
+            :type label: string
+            :type s: string
+        """
+        self.append(self._item(label))
+        self.append(s)

--- a/tests/args.py
+++ b/tests/args.py
@@ -11,7 +11,7 @@ matplotlib.use('Agg')  # Not to use X server. For TravisCI.
 import matplotlib.pyplot as pyplot
 
 from pylatex import Document, Section, Math, Table, Figure, Package, TikZ, \
-    Axis, Plot, Plt
+    Axis, Plot, Plt, Itemize, Enumerate, Description
 from pylatex.command import Command
 from pylatex.numpy import Matrix, VectorName
 from pylatex.utils import escape_latex, fix_filename, dumps_list, bold, \
@@ -106,3 +106,16 @@ bold(s='')
 italic(s='')
 
 verbatim(s='', delimiter='|')
+
+# Lists
+itemize = Itemize()
+itemize.add_item("item")
+itemize.append("append")
+
+enum = Enumerate()
+enum.add_item("item")
+enum.append("append")
+
+desc = Description()
+desc.add_item("label", "item")
+desc.append("append")


### PR DESCRIPTION
I've added some support for LaTeX lists like \begin{enumerate}, and \begin{itemize}. As it stands it purely takes in an Item as text and dumps it in there. I used table.py as a reference, so if anything seems a little weird (like the copyright notice, for example!) then I'm happy to change it as you see fit.

I've run testall.sh and corrected the flake8 issues and things seem to be ok, an added a simple demonstration under examples/lists_example.py. Please let me know if there's any other changes I should make before this is suitable to accept.