### PR TITLE
Propagating packages from subcontainers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Arguments for plt.savefig
 
 ### Fixed
+- Propagate packages recursively add packages of sub containers
 - Make cleanup of files Windows compatible
 - Filenames can be paths (`foo/bar/my_pdf`).
 - Replace `filename` by `filepath` in the names of the arguments.

--- a/pylatex/base_classes.py
+++ b/pylatex/base_classes.py
@@ -102,6 +102,8 @@ class BaseLaTeXContainer(BaseLaTeXClass, UserList):
 
         for item in self.data:
             if isinstance(item, BaseLaTeXClass):
+                if isinstance(item, BaseLaTeXContainer):
+                    item.propegate_packages()
                 for p in item.packages:
                     self.packages.add(p)
 


### PR DESCRIPTION
To allow for multiple levels of `BaseLaTeXContainer`, it is needed to propagate the inner containers packages up to the toplevel one. 