### PR TITLE
WIP: Adds support for quantities python package (latex: siunitx)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
     - cd ..
     - ./convert_to_py2.sh
     - pip install -e .[all]
-    - sudo apt-get install texlive-latex-extra texlive-pictures
+    - sudo apt-get install texlive-latex-extra texlive-pictures texlive-science
 script: ./testall.sh

--- a/examples/quantities_ex.py
+++ b/examples/quantities_ex.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+import quantities as pq
+
+from pylatex import Document, Section, Subsection, Math
+from pylatex.quantities import Quantity
+
+doc = Document()
+section = Section('Quantity tests')
+subsection = Subsection('Scalars')
+
+G = pq.constants.Newtonian_constant_of_gravitation
+moon_earth_distance = 384400*pq.km
+moon_mass = 7.34767309e22 * pq.kg
+earth_mass = 5.972e24 * pq.kg
+moon_earth_force = G*moon_mass*earth_mass/moon_earth_distance**2
+q1 = Quantity(moon_earth_force.rescale(pq.newton))
+math = Math(data=['F=', q1])
+subsection.append(math)
+section.append(subsection)
+doc.append(section)
+doc.generate_pdf()

--- a/pylatex/quantities.py
+++ b/pylatex/quantities.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+    pylatex.quantities
+    ~~~~~~~~~~~~~~~~~~
+
+    This module implements the classes that deals with quantities objects.
+    It requires the latex package SIunitx.
+
+    :copyright: (c) 2015 by Björn Dahlgren.
+    :license: MIT, see License for more details.
+"""
+
+from operator import itemgetter
+
+import numpy as np
+
+from pylatex.command import Command
+from pylatex.package import Package
+
+
+def _dimensionality_to_siunitx(dim):
+    string = ''
+    items = dim.items()
+    for unit, power in sorted(items, key=itemgetter(1), reverse=True):
+        if power < 0:
+            substring = r'\per'
+            power = -power
+        elif power == 0:
+            continue
+        else:
+            substring = ''
+        substring += '\\' + unit.name
+        if power > 1:
+            substring += r'\tothe{' + str(power) + '}'
+        string += substring
+    return string
+
+
+class Quantity(Command):
+    def __init__(self, quantity, format_cb=None):
+        """
+            :param quantity:
+            :param fmtstr:
+
+            :type quantity: :class:`quantities.Quantity` instance
+            :type fmtstr: callable
+        """
+        self.quantity = quantity
+        if format_cb is None:
+            magnitude_str = np.array_str(quantity.magnitude)
+        else:
+            magnitude_str = format_cb(quantity.magnitude)
+        unit_str = _dimensionality_to_siunitx(quantity.dimensionality)
+        super().__init__(command='SI', arguments=(magnitude_str, unit_str),
+                         packages=[Package('siunitx')])

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ else:
 extras = {
     'matrices': ['numpy'],
     'matplotlib': ['matplotlib'],
+    'quantities': ['quantities'],
     'testing': ['flake8', 'pep8-naming'],
 }
 

--- a/tests/args.py
+++ b/tests/args.py
@@ -6,6 +6,7 @@
 """
 
 import numpy as np
+import quantities as pq
 import matplotlib
 matplotlib.use('Agg')  # Not to use X server. For TravisCI.
 import matplotlib.pyplot as pyplot
@@ -15,6 +16,7 @@ from pylatex import Document, Section, Math, Tabular, Figure, SubFigure, \
     MultiColumn, MultiRow
 from pylatex.command import Command
 from pylatex.numpy import Matrix, VectorName
+from pylatex.quantities import Quantity
 from pylatex.utils import escape_latex, fix_filename, dumps_list, bold, \
     italic, verbatim
 
@@ -100,6 +102,10 @@ M = np.matrix([[2, 3, 4],
                [0, 0, 1],
                [0, 0, 2]])
 m = Matrix(matrix=M, name='', mtype='p', alignment=None)
+
+# Quantities
+q1 = Quantity(quantity=1*pq.kg)
+q2 = Quantity(quantity=1*pq.kg, format_cb=lambda x: str(int(x)))
 
 # Package
 p = Package(name='', base='usepackage', options=None)

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import quantities as pq
+
+from pylatex.quantities import _dimensionality_to_siunitx, Quantity
+
+
+def test_quantity():
+    v = 1 * pq.m/pq.s
+
+    q1 = Quantity(v)
+    assert q1.dumps() == r'\SI{1.0}{\meter\per\second}'
+
+    q2 = Quantity(v, format_cb=lambda x: str(int(x)))
+    assert q2.dumps() == r'\SI{1}{\meter\per\second}'
+
+
+def test_dimensionality_to_siunitx():
+    assert _dimensionality_to_siunitx((pq.volt/pq.kelvin).dimensionality) == \
+        r'\volt\per\Kelvin'
+
+if __name__ == '__main__':
+    test_quantity()
+    test_dimensionality_to_siunitx()


### PR DESCRIPTION
This is a friendly suggestion of adding support for [quantities](http://pythonhosted.org/quantities/).
This prototype uses [siunitx](https://www.ctan.org/pkg/siunitx). This implementation (modelled after the numpy support) is far from complete and I expect many corner cases which would need special attention. But before I put in more effort, I would like to hear if there is any interest in including this upstream.

Best regards,
Björn