### PR TITLE
Fix scripts for python3 use

### DIFF
--- a/docs/create_doc_files.sh
+++ b/docs/create_doc_files.sh
@@ -1,4 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Optional named arguments:
+#      -p COMMAND: the python command that should be used, e.g. -p python3
+
+# Default values
+python="python"
+
+# Check if a command line argument was provided as an input argument.
+while getopts "p:" opt; do
+  case $opt in
+    p)
+      python=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
 ARGS='--separate --force --no-headings --no-toc'
 
 echo Cleaning pylatex and examples
@@ -15,7 +38,7 @@ rm source/pylatex/pylatex.base_classes.rst
 for f in ../examples/*.py; do
     name=`echo $f | cut -d'/' -f3 | cut -d'.' -f1`
     rst=source/examples/${name}.rst
-    python gen_example_title.py "$name" > $rst
+    $python gen_example_title.py "$name" > $rst
     echo Creating file ${rst}
     echo .. automodule:: examples.$name >> $rst
     echo >> $rst
@@ -30,7 +53,7 @@ for f in ../examples/*.py; do
     echo ------------------ >> $rst
     # Compiling examples to png
     cd source/_static/examples
-    python ../../../$f > /dev/null
+    $python ../../../$f > /dev/null
     for pdf in ${name}*.pdf; do
         convert $pdf ${pdf}.png
         echo ".. figure:: /_static/examples/${pdf}.png" >> ../../../$rst

--- a/testall.sh
+++ b/testall.sh
@@ -62,9 +62,8 @@ else
     main_folder=.
 fi
 
-
 echo -e '\e[32mTesting tests directory\e[0m'
-if ! nosetests tests/*; then
+if ! nosetests3 tests/*; then
     exit 1
 fi
 
@@ -79,7 +78,6 @@ for f in $main_folder/examples/*.py; do
     fi
 done
 
-
 if [ "$clean" = 'TRUE' ]; then
     rm *.pdf *.log *.aux *.tex
 fi
@@ -88,7 +86,7 @@ fi
 if [ "$python_version" = '3' -a "$nodoc" != 'TRUE' ]; then
     echo -e '\e[32mChecking for errors in docs and docstrings\e[0m'
     cd docs
-    ./create_doc_files.sh
+    ./create_doc_files.sh -p $python
     make clean
     if ! sphinx-build -b html -d build/doctrees/ source build/html -nW; then
         exit 1


### PR DESCRIPTION
Currently, ``testall.sh`` and ``docs/create_doc_files.sh`` won't work in a ``python3`` environment.

The ``-p`` switch is present, but does not propagate to ``docs/create_doc_files.sh``. Also the use of ``nosetests`` in this context is wrong and should be replaced by ``nosetests3``.
This PR attempts to fix both issues.

Please note that atm there is a switch missing for the nosetests3/nosetests thingy... Need to fix that before a possible merge. Just wanted to make sure you're interested anyway.