### PR TITLE
Add error bar feature

### DIFF
--- a/pylatex/pgfplots.py
+++ b/pylatex/pgfplots.py
@@ -67,10 +67,17 @@ class Plot(LatexObject):
         :class:`~pylatex.base_classes.command.Options` instance
     """
 
-    def __init__(self, name=None, func=None, coordinates=None, options=None):
+    def __init__(
+            self,
+            name=None,
+            func=None,
+            coordinates=None,
+            error_bar=None,
+            options=None):
         self.name = name
         self.func = func
         self.coordinates = coordinates
+        self.error_bar = error_bar
         self.options = options
 
         packages = [Package('pgfplots'), Command('pgfplotsset',
@@ -90,8 +97,18 @@ class Plot(LatexObject):
         if self.coordinates is not None:
             string += ' coordinates {\n'
 
-            for x, y in self.coordinates:
-                string += '(' + str(x) + ',' + str(y) + ')\n'
+            if self.error_bar is None:
+                for x, y in self.coordinates:
+                    # ie: "(x,y)"
+                    string += '(' + str(x) + ',' + str(y) + ')\n'
+
+            else:
+                for (x, y), (e_x, e_y) in zip(self.coordinates,
+                                              self.error_bar):
+                    # ie: "(x,y) +- (e_x,e_y)"
+                    string += '(' + str(x) + ',' + str(y) + \
+                        ') +- (' + str(e_x) + ',' + str(e_y) + ')\n'
+
             string += '};\n\n'
 
         elif self.func is not None:

--- a/tests/args.py
+++ b/tests/args.py
@@ -125,7 +125,7 @@ def test_tikz():
 
     Axis(data=None, options=None)
 
-    Plot(name=None, func=None, coordinates=None, options=None)
+    Plot(name=None, func=None, coordinates=None, error_bar=None, options=None)
 
 
 def test_lists():


### PR DESCRIPTION
I really enjoy this library, it's really helpful! Since I needed to plot some data with error bars, I added the feature.

You can test it here:
```python
#!/usr/bin/python
from pylatex import Document, Section, Figure, Axis, Plot, TikZ

if __name__ == '__main__':
    doc = Document()
    with doc.create(Section('Error bars')):
        with doc.create(Figure(position='h!')) as figure:
            with doc.create(TikZ()) as tikz:
                with doc.create(Axis()) as axis:
                    x1 = [1, 2, 3, 4, 5]
                    x2 = [1.02, 1.9, 3.02, 4.1, 4.98]
                    y1 = [25, 16, 9, 4, 1]
                    y2 = [28.3, 16.08, 8.2, 5.11, 1.05]
                    e_x = [0.08, 0.124, 0.18, 0.121, 0.102]
                    e_y = [0.251, 2.256, 3.972, 8.326, 10.874]
                    axis.append(Plot(
                            name = u'No error bar',
                            options = u"color=red",
                            coordinates = zip(x1, y1),
                            ))
                    axis.append(Plot(
                            name = u'Error bar',
                            options = u"color=blue, error bars/.cd, y dir=both, y explicit, x dir=both, x explicit",
                            coordinates = zip(x2, y2),
                            error_bar = zip(e_x, e_y)
                            ))


    doc.generate_pdf()
```