### PR TITLE
Better item handling in _latex_item_to_string 

### DIFF
--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -7,6 +7,7 @@ This module implements some simple utility functions.
 """
 
 import os.path
+import pylatex.base_classes
 import shutil
 import tempfile
 
@@ -131,7 +132,7 @@ def _latex_item_to_string(item, escape=False, post_convert=None):
     :rtype: str
     """
 
-    if hasattr(item, 'dumps'):
+    if isinstance(item, pylatex.base_classes.LatexObject):
         s = item.dumps()
     else:
         s = str(item)

--- a/tests/utils_latex_item_to_string.py
+++ b/tests/utils_latex_item_to_string.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from pylatex.utils import _latex_item_to_string
+from pylatex.base_classes import LatexObject
+
+TEST_STR = 'hello'
+
+
+def test_string():
+    name = 'abc'
+    assert _latex_item_to_string(name) == name
+
+
+def test_user_latex_object():
+    class TestLatexObject(LatexObject):
+        def dumps(self):
+            return TEST_STR
+
+    assert _latex_item_to_string(TestLatexObject()) == TEST_STR
+
+
+def test_foreign_object():
+    class ForeignObject:
+        def dumps(self):
+            return 15
+
+        def __str__(self):
+            return TEST_STR
+
+    assert _latex_item_to_string(ForeignObject()) == TEST_STR


### PR DESCRIPTION
Hi,
I thing that is good idea to check whether item supports latex dumps by abstract classes than hassattr('dumps'). It solves many situations to avoid conflicts whether item has foreign dumps function or the right one that creates latex representation.
PS (The particular case that observed the problem):
I've tried to create table with numpy numbers but the problem is that they have dumps function that returns picke byte array instead of supposed string. But the PyLatex return some weird error because the code supposed that dumps function return latex string.