### PR TITLE
Fixed a bug when 'filepath' in 'generate_pdf' method of the 'document' class is a pure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ been moved an renamed.
 - The old `Table` class is renamed to `Tabular`. A new `Table` class has been
     created that represents the `table` LaTeX environment, which can be used to
     create a floating table.
+    
+- Fixed a bug in the `document` class, that lead to an error if a filepath without basename was provided.
+
+- Fixed the testall.sh script such that sphinx and nosetests get called with the correct python version.
 
 ### Added
 - Lots of documentation!!!!!

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -114,6 +114,10 @@ class Document(Container):
         cur_dir = os.getcwd()
         dest_dir = os.path.dirname(filepath)
         basename = os.path.basename(filepath)
+
+        if basename == '':
+            basename = 'default_basename'
+
         os.chdir(dest_dir)
 
         self.generate_tex(basename)
@@ -157,4 +161,7 @@ class Document(Container):
         if filepath == '':
             return self.default_filepath
         else:
+            if os.path.basename(filepath) == '':
+                filepath = os.path.join(filepath, os.path.basename(
+                    self.default_filepath))
             return filepath

--- a/testall.sh
+++ b/testall.sh
@@ -63,7 +63,7 @@ else
 fi
 
 echo -e '\e[32mTesting tests directory\e[0m'
-if ! nosetests tests/*; then
+if ! $python $(which nosetests) tests/*; then
     exit 1
 fi
 
@@ -88,7 +88,7 @@ if [ "$python_version" = '3' -a "$nodoc" != 'TRUE' ]; then
     cd docs
     ./create_doc_files.sh -p $python
     make clean
-    if ! sphinx-build -b html -d build/doctrees/ source build/html -nW; then
+    if ! $python $(which sphinx-build) -b html -d build/doctrees/ source build/html -nW; then
         exit 1
     fi
 fi

--- a/tests/jobname.py
+++ b/tests/jobname.py
@@ -22,5 +22,15 @@ def test():
     doc.generate_pdf()
 
     assert os.path.isfile(path + '.pdf')
+    shutil.rmtree(folder)
+
+    folder = 'tmp_jobname2'
+    os.makedirs(folder)
+    path = os.path.join(folder, 'jobname_test_dir2')
+
+    doc = Document(path, title='Jobname test dir', maketitle=True)
+    doc.generate_pdf(os.path.join(folder, ''))
+
+    assert os.path.isfile(path + '.pdf')
 
     shutil.rmtree(folder)


### PR DESCRIPTION
If the 'filepath' argument of the 'generate_pdf' method of the 'document' class was a pure path, e.g. /home/bla/documents/mylatex/ , the latex compilation failed as the basename was empty.

I fixed this by changing the 'select_filepath' method to use add the basename of the 'default_filepath' to the new filepath. Further if at the document initialization the 'default_filepath' was given a 'default_basename' in case it itself did not contain any basenames.

Further I did some minor adaption with the testall.sh script, such that an user provided python version does work with sphinx and nosetests.