### PR TITLE
Introduced error handling when adding table rows of mismatching size,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
-This realease will bring some great changes. The whole package has been
+This release will bring some great changes. The whole package has been
 refactored and actual documentation has been added. Because of this, things have
 been moved an renamed.
 
 ### Changed
+- Tables now raise an exception when rows with wrong size are added
 - The base_classes submodule has been split into multiple sub-submodules.
 - The old baseclasses have been renamed as well. They now have easier names that
     better show their purpose.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ doc.packages.append(Package('geometry', options=['tmargin=1cm',
                                                  'lmargin=10cm']))
 
 with doc.create(Section('The simple stuff')):
-    doc.append('Some regular text and some ' + italic('italic text. '))
-    doc.append(escape_latex('\nAlso some crazy characters: $&#{}'))
+    doc.append('Some regular text and some ')
+    doc.append(italic('italic text. '))
+    doc.append('\nAlso some crazy characters: $&#{}')
     with doc.create(Subsection('Math that is incorrect')) as math:
         doc.append(Math(data=['2*3', '=', 9]))
 

--- a/pylatex/__init__.py
+++ b/pylatex/__init__.py
@@ -19,3 +19,4 @@ from .lists import Enumerate, Itemize, Description
 from .quantities import Quantity
 from .base_classes import Command
 from .utils import NoEscape
+from .errors import TableRowSizeError

--- a/pylatex/base_classes/__init__.py
+++ b/pylatex/base_classes/__init__.py
@@ -7,7 +7,6 @@ from .table import TabularBase
 from .section import SectionBase
 from .float import Float
 
-
 # Old names of the base classes for backwards compatibility
 BaseLaTeXClass = LatexObject
 BaseLaTeXContainer = Container

--- a/pylatex/base_classes/command.py
+++ b/pylatex/base_classes/command.py
@@ -2,7 +2,7 @@
 """
 This module implements a class that implements a latex command.
 
-This can be used directly or it can be inherrited to make an easier interface
+This can be used directly or it can be inherited to make an easier interface
 to it.
 
 ..  :copyright: (c) 2014 by Jelte Fennema.

--- a/pylatex/base_classes/containers.py
+++ b/pylatex/base_classes/containers.py
@@ -123,7 +123,7 @@ class Environment(Container):
             Some content that is in the environment
         \end{environment_name}
 
-    The text that is used in the place of environment_name is by defalt the
+    The text that is used in the place of environment_name is by default the
     name of the class in lowercase. However, this default can be overridden by
     setting the environment_name class variable when declaring the class.
     """
@@ -156,7 +156,7 @@ class Environment(Container):
 
         string = ''
 
-        # Something other than None needs to be used as extra argumets, that
+        # Something other than None needs to be used as extra arguments, that
         # way the options end up behind the latex_name argument.
         if self.arguments is None:
             extra_arguments = Arguments()

--- a/pylatex/base_classes/latex_object.py
+++ b/pylatex/base_classes/latex_object.py
@@ -40,7 +40,7 @@ class LatexObject(metaclass=_CreatePackages):
 
     _latex_name = None
 
-    #: Set this to an itterable to override the list of default repr
+    #: Set this to an iterable to override the list of default repr
     #: attributes.
     _repr_attributes_override = None
     #: Set this to a dict to change some of the default repr attributes to

--- a/pylatex/errors.py
+++ b/pylatex/errors.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+This module implements Error classes.
+
+..  :copyright: (c) 2015 by Rene Beckmann.
+    :license: MIT, see License for more details.
+"""
+
+
+class PyLaTeXError(Exception):
+    """A Base class for all PyLaTeX Exceptions."""
+
+
+class TableError(PyLaTeXError):
+    """A Base class for all errors concerning tables."""
+
+
+class TableRowSizeError(TableError):
+    """Error for wrong table row size."""

--- a/tests/args.py
+++ b/tests/args.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as pyplot
 
 from pylatex import Document, Section, Math, Tabular, Figure, SubFigure, \
     Package, TikZ, Axis, Plot, Itemize, Enumerate, Description, MultiColumn, \
-    MultiRow, Command, Matrix, VectorName, Quantity
+    MultiRow, Command, Matrix, VectorName, Quantity, TableRowSizeError
 from pylatex.utils import escape_latex, fix_filename, dumps_list, bold, \
     italic, verbatim
 
@@ -66,12 +66,15 @@ def test_table():
 
     t.add_hline(start=None, end=None)
 
-    t.add_row(cells=(1, 2), escape=False)
+    t.add_row(cells=(1, 2), escape=False, strict=True)
 
     # MultiColumn/MultiRow.
-    t.add_row((MultiColumn(size=2, align='|c|', data='MultiColumn'),))
+    t.add_row((MultiColumn(size=2, align='|c|', data='MultiColumn'),),
+              strict=True)
 
-    t.add_row((MultiRow(size=2, width='*', data='MultiRow'),))
+    # One multiRow-cell in that table would not be proper LaTeX,
+    # so strict is set to False
+    t.add_row((MultiRow(size=2, width='*', data='MultiRow'),), strict=False)
 
     repr(t)
 
@@ -169,3 +172,32 @@ def test_utils():
     italic(s='')
 
     verbatim(s='', delimiter='|')
+
+
+def test_errors():
+    # Errors
+
+    # TableRowSizeError
+
+    # General test
+
+    try:
+        raise TableRowSizeError
+    except TableRowSizeError:
+        pass
+
+    # Positive test, expected to raise Error
+
+    t = Tabular(table_spec='|c|c|', data=None, pos=None)
+    try:
+        # Wrong number of cells in table should raise an exception
+        t.add_row(cells=(1, 2, 3), escape=False, strict=True)
+    except TableRowSizeError:
+        pass
+
+    # Negative test, should not raise
+    try:
+        # Wrong number with strict=False should not raise an exception
+        t.add_row(cells=(1, 2, 3), escape=False, strict=False)
+    except TableRowSizeError:
+        raise


### PR DESCRIPTION
I made a little error check on adding rows to table, because LaTeX actually doesn't like table rows with the wrong number of cells. I don't know if you like the way I did it, but as far as I can see, it does what it should. Also, I fixed the example in the readme, because I did not work for me:
When you append some text and an italic at the same time, thats str + NoEscape, which delivers a str, so the latex command for italic will be escaped again later, which does not work. Also, when you try to display special chars, you should not append them with latex escape, as they are then escaped two times, so \& becomes \textbackslash{}\\& or something alike.
You actually didn't do it this way in your example folder, so maybe you forgot to change it or something?