### PR TITLE
Add version string to __init__.py

### DIFF
--- a/pylatex/__init__.py
+++ b/pylatex/__init__.py
@@ -20,3 +20,5 @@ from .quantities import Quantity
 from .base_classes import Command, UnsafeCommand
 from .utils import NoEscape
 from .errors import TableRowSizeError
+
+__version__ = str('1.0.1dev')


### PR DESCRIPTION
In the future, it could be better implemented using the versioneer package but, at least, it introduces now such a useful string.