### PR TITLE
Expose more of siunitx's capabilities

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,11 +17,15 @@ This version might not be stable, but to install it use::
 Changed
 ~~~~~~~
 - Allow overriding of the default numbering of `.Section` class.
+- `.Parameters` now unpacks a dict as keyword arguments when passed a single
+  dictionary as argument.
 
 Added
 ~~~~~
 - Add the ``textcomp`` package by default. This way some special glyphs, like
   the Euro (€) Symbol can be used in the source.
+- `.Quantity` got a new  ``options`` keyword argument and learned to handle
+  uncertain quantities.
 
 Fixed
 ~~~~~

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -53,7 +53,7 @@ the dependencies.
 2. Activate it by running (you should do this whenever you start working on
    your changes)::
 
-    . venv bin activate
+    . venv/bin/activate
 
 3. Install all the development dependencies inside the virtual environment by
    running::

--- a/examples/quantities_ex.py
+++ b/examples/quantities_ex.py
@@ -21,7 +21,8 @@ if __name__ == '__main__':
     moon_mass = 7.34767309e22 * pq.kg
     earth_mass = 5.972e24 * pq.kg
     moon_earth_force = G * moon_mass * earth_mass / moon_earth_distance**2
-    q1 = Quantity(moon_earth_force.rescale(pq.newton))
+    q1 = Quantity(moon_earth_force.rescale(pq.newton),
+                  options={'round-precision': 4, 'round-mode': 'figures'})
     math = Math(data=['F=', q1])
     subsection.append(math)
     section.append(subsection)

--- a/examples/quantities_ex.py
+++ b/examples/quantities_ex.py
@@ -14,8 +14,8 @@ from pylatex import Document, Section, Subsection, Math, Quantity
 if __name__ == '__main__':
     doc = Document()
     section = Section('Quantity tests')
-    subsection = Subsection('Scalars')
 
+    subsection = Subsection('Scalars with units')
     G = pq.constants.Newtonian_constant_of_gravitation
     moon_earth_distance = 384400 * pq.km
     moon_mass = 7.34767309e22 * pq.kg
@@ -26,5 +26,22 @@ if __name__ == '__main__':
     math = Math(data=['F=', q1])
     subsection.append(math)
     section.append(subsection)
+
+    subsection = Subsection('Scalars without units')
+    world_population = 7400219037
+    N = Quantity(world_population, options={'round-precision': 2,
+                                            'round-mode': 'figures'},
+                 format_cb="{0:23.17e}".format)
+    subsection.append(Math(data=['N=', N]))
+    section.append(subsection)
+
+    subsection = Subsection('Scalars with uncertainties')
+    width = pq.UncertainQuantity(7.0, pq.meter, .4)
+    length = pq.UncertainQuantity(6.0, pq.meter, .3)
+    area = Quantity(width*length, options='separate-uncertainty',
+                    format_cb=lambda x: "{0:.1f}".format(float(x)))
+    subsection.append(Math(data=['A=', area]))
+    section.append(subsection)
+
     doc.append(section)
     doc.generate_pdf('quantities_ex')

--- a/pylatex/base_classes/command.py
+++ b/pylatex/base_classes/command.py
@@ -211,9 +211,12 @@ class Parameters(LatexObject):
             Keyword parameters
         """
 
-        if len(args) == 1 and hasattr(args[0], '__iter__') and\
-                not isinstance(args[0], str):
-            args = args[0]
+        if len(args) == 1 and not isinstance(args[0], str):
+            if hasattr(args[0], 'items') and len(kwargs) == 0:
+                kwargs = args[0]  # do not just iterate over the dict keys
+                args = ()
+            elif hasattr(args[0], '__iter__'):
+                args = args[0]
 
         self._positional_args = list(args)
         self._key_value_args = dict(kwargs)

--- a/pylatex/quantities.py
+++ b/pylatex/quantities.py
@@ -10,7 +10,7 @@ It requires the latex package SIunitx.
 
 from operator import itemgetter
 
-from .base_classes import Command
+from .base_classes import Command, Options
 from .package import Package
 from .utils import NoEscape
 
@@ -38,23 +38,39 @@ class Quantity(Command):
 
     packages = [Package('siunitx')]
 
-    def __init__(self, quantity, *, format_cb=None):
-        """
+    def __init__(self, quantity, options=None, *, format_cb=None):
+        r"""
         Args
         ----
         quantity: `quantities.quantity.Quantity`
             The quantity that should be displayed
-        fmtstr: callable
+        options: None, str, list or `~.Options`
+            Options of the command. These are placed in front of the arguments.
+        format_cb: callable
             A function which formats the number in the quantity. By default
             this uses `numpy.array_str`.
+
+        Examples
+        --------
+        >>> import quantities as pq
+        >>> speed = 3.14159265 * pq.meter / pq.second
+        >>> Quantity(speed, options={'round-precision': 3,
+        ...                          'round-mode': 'figures'})
+        '\\SI[round-mode=figures,round-precision=3]{3.14159265}{\meter\per\second}'
+
         """
         import numpy as np
 
         self.quantity = quantity
         self._format_cb = format_cb
+
         if format_cb is None:
             magnitude_str = np.array_str(quantity.magnitude)
         else:
             magnitude_str = format_cb(quantity.magnitude)
         unit_str = _dimensionality_to_siunitx(quantity.dimensionality)
-        super().__init__(command='SI', arguments=(magnitude_str, unit_str))
+        if options is not None:
+            options = Options(options)
+            options._escape = False  # siunitx uses dashes in kwargs
+        super().__init__(command='SI', arguments=(magnitude_str, unit_str),
+                         options=options)

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -18,6 +18,17 @@ def test_quantity():
     assert q3.dumps() == ref
 
 
+def test_quantity_float():
+    q1 = Quantity(42.0)
+    assert q1.dumps() == r'\num{42.0}'
+
+
+def test_quantity_uncertain():
+    t = pq.UncertainQuantity(7., pq.second, 1.)
+    q1 = Quantity(t)
+    assert q1.dumps() == r'\SI{7.0 +- 1.0}{\second}'
+
+
 def test_dimensionality_to_siunitx():
     assert _dimensionality_to_siunitx((pq.volt/pq.kelvin).dimensionality) == \
         r'\volt\per\Kelvin'

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -13,6 +13,10 @@ def test_quantity():
     q2 = Quantity(v, format_cb=lambda x: str(int(x)))
     assert q2.dumps() == r'\SI{1}{\meter\per\second}'
 
+    q3 = Quantity(v, options={'zero-decimal-to-integer': 'true'})
+    ref = r'\SI[zero-decimal-to-integer=true]{1.0}{\meter\per\second}'
+    assert q3.dumps() == ref
+
 
 def test_dimensionality_to_siunitx():
     assert _dimensionality_to_siunitx((pq.volt/pq.kelvin).dimensionality) == \


### PR DESCRIPTION
This extends the capabilities of `Quantity` to pass options to siunitx command `\SI`

I struggled a bit with dealing with escaping of `Options`. Note the suggested change in behaviour
of `Parameters` and the modification of private variable `_escape` in `quantities.py`.
Is there another preferred way of achieving this which I have overlooked?

TODO:
- [x] Allow to pass options
- [x] Support for `quantities.UncertainQuantity`
- [x] Support for using Python `float` with `pylatex.Quantity` (which would map to `siunitx`'s `\num{}`)
- [x] Update `changelog.rst`