### PR TITLE
taking into account Windows paths

### DIFF
--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -124,7 +124,7 @@ def fix_filename(path):
 
     """
 
-    path_parts = path.split('/')
+    path_parts = path.split('/' if os.name == 'posix' else '\\')
     dir_parts = path_parts[:-1]
 
     filename = path_parts[-1]


### PR DESCRIPTION
    >>> fix_filename(r"foo.bar.pdf")
    '{foo.bar}.pdf'
    >>> fix_filename(r"C:\foo.bar.pdf")
    'C:/{foo.bar}.pdf'
    >>> fix_filename(r'C:\foo.bar.baz\document.pdf')
    'C:/foo.bar.baz/document.pdf'

It's important to have slash instead of backslash in results even in Windows envirenment, because latex distributions only manage posix paths.