### PR TITLE
Classes as mappers and quick fix for MultiRow/MultiColumn

### DIFF
--- a/pylatex/position.py
+++ b/pylatex/position.py
@@ -50,6 +50,16 @@ class Center(Environment):
 
     packages = [Package('ragged2e')]
 
+    def __init__(self, data=None):
+        """
+        Args
+        ----
+        data: str or `~.LatexObject`
+            The data to be positioned
+        """
+
+        super().__init__(data=data)
+
 
 class FlushLeft(Center):
     r"""Left-aligned environment."""

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -293,6 +293,7 @@ class MultiRow(Container):
         super().__init__(data=data)
 
         if color is not None:
+            self.packages.append(Package('xcolor', options='table'))
             color_command = Command("cellcolor", arguments=color)
             self.append(color_command)
 

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -247,6 +247,7 @@ class MultiColumn(Container):
 
         # Add a cell color to the MultiColumn
         if color is not None:
+            self.packages.append(Package('xcolor', options='table'))
             color_command = Command("cellcolor", arguments=color)
             self.append(color_command)
 

--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -182,6 +182,9 @@ def dumps_list(l, *, escape=True, token='%\n', mapper=None, as_content=True):
         else:
             strings = (mapper(s) for s in strings)
 
+    strings = [s.dumps() for s in strings if isinstance(
+        s, pylatex.base_classes.LatexObject)]
+
     return NoEscape(token.join(strings))
 
 

--- a/tests/args.py
+++ b/tests/args.py
@@ -320,6 +320,8 @@ def test_utils():
     fix_filename(path='')
 
     dumps_list(l=[], escape=False, token='\n')
+    # Test dumps_list with a class as a mapper
+    dumps_list(l=["Item1", "Item2"], mapper=[bold, Center], token='\n')
 
     bold(s='')
 

--- a/tests/args.py
+++ b/tests/args.py
@@ -236,15 +236,15 @@ def test_position():
     repr(VerticalSpace(size="20pt", star=True))
 
     # Test alignment environments
-    center = Center()
+    center = Center("centered data")
     center.append("append")
     repr(center)
 
-    right = FlushRight()
+    right = FlushRight("right alligned data")
     right.append("append")
     repr(right)
 
-    left = FlushLeft()
+    left = FlushLeft("left alligned data")
     left.append("append")
     repr(left)
 


### PR DESCRIPTION
Hello Jelte,

The change in dumps_list utils will allow simple classes with just a data argument to be used as mappers (Center, FlushLeft, FlushRight). I also added a quick fix for adding colours to MultiColumn/MultiRow elements, I forgot to add the xcolor package before which was causing errors during latex compilation.

Thanks,
Vladimir