### PR TITLE
Windows compatibility

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -238,7 +238,7 @@ class Document(Environment):
                     # Try latexmk cleaning first
                     subprocess.check_output(['latexmk', '-c', basename],
                                             stderr=subprocess.STDOUT)
-                except (OSError, IOError) as e:
+                except (OSError, IOError, subprocess.CalledProcessError) as e:
                     # Otherwise just remove some file extensions.
                     extensions = ['aux', 'log', 'out', 'fls',
                                   'fdb_latexmk']

--- a/pylatex/figure.py
+++ b/pylatex/figure.py
@@ -6,7 +6,7 @@ This module implements the class that deals with graphics.
     :license: MIT, see License for more details.
 """
 
-import os.path
+import posixpath
 
 from .utils import fix_filename, make_temp_dir, NoEscape, escape_latex
 from .base_classes import Float, UnsafeCommand
@@ -57,7 +57,7 @@ class Figure(Float):
 
         tmp_path = make_temp_dir()
 
-        filename = os.path.join(tmp_path, str(uuid.uuid4()) + '.pdf')
+        filename = posixpath.join(tmp_path, str(uuid.uuid4()) + '.pdf')
 
         plt.savefig(filename, *args, **kwargs)
 


### PR DESCRIPTION
Pull request including some compatibility issues with windows and not having perl installed:
- using posixpath instead of os.path for path to matplotlib plots (os.path on windos gives double backslashes which the latex compilator doesnt like)
- included error type subprocess.CalledProcessError to catch when cleaning after pdf generation. If perl is not installed on a windows machine, this error is raised when trying to clean with latexmk.