### PR TITLE
tilde filepath fix for graphics

### DIFF
--- a/pylatex/figure.py
+++ b/pylatex/figure.py
@@ -157,9 +157,6 @@ class StandAloneGraphic(UnsafeCommand):
             Specifies the options for the image (ie. height, width)
         """
 
-        if '~' in filename:
-            filename = detokenize(filename)
-
         arguments = [NoEscape(filename)]
 
         super().__init__(command=self._latex_name, arguments=arguments,

--- a/pylatex/figure.py
+++ b/pylatex/figure.py
@@ -8,7 +8,7 @@ This module implements the class that deals with graphics.
 
 import posixpath
 
-from .utils import fix_filename, make_temp_dir, NoEscape, escape_latex
+from .utils import fix_filename, make_temp_dir, NoEscape, escape_latex, detokenize
 from .base_classes import Float, UnsafeCommand
 from .package import Package
 import uuid
@@ -157,8 +157,13 @@ class StandAloneGraphic(UnsafeCommand):
             Specifies the options for the image (ie. height, width)
         """
 
+        if '~' in filename:
+            filename = detokenize(filename)
+
         arguments = [NoEscape(filename)]
 
         super().__init__(command=self._latex_name, arguments=arguments,
                          options=image_options,
                          extra_arguments=extra_arguments)
+
+

--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -122,6 +122,8 @@ def fix_filename(path):
     '/etc/local/{foo.bar}.pdf'
     >>> fix_filename("/etc/local/foo.bar.baz/document.pdf")
     '/etc/local/foo.bar.baz/document.pdf'
+    >>> fix_filename("/etc/local/foo.bar.baz/foo~1/document.pdf")
+    '\detokenize{/etc/local/foo.bar.baz/foo~1/document.pdf}'
     """
 
     path_parts = path.split('/' if os.name == 'posix' else '\\')
@@ -134,7 +136,12 @@ def fix_filename(path):
         filename = '{' + '.'.join(file_parts[0:-1]) + '}.' + file_parts[-1]
 
     dir_parts.append(filename)
-    return '/'.join(dir_parts)
+    fixed_path = '/'.join(dir_parts)
+
+    if '~' in fixed_path:
+        fixed_path = detokenize(fixed_path)
+
+    return fixed_path
 
 
 def dumps_list(l, *, escape=True, token='%\n', mapper=None, as_content=True):

--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -312,6 +312,36 @@ def verbatim(s, *, delimiter='|'):
 
     return NoEscape(r'\verb' + delimiter + s + delimiter)
 
+def detokenize(s, *, escape=True):
+    r"""Add a string to the detokenize command 
+
+    detokenize wraps a given string in the LaTeX command \detokenize{}. This is
+    useful for tilde files on windows that cannot be referenced normally.
+
+    Args
+    ----
+    s : str
+        The string to be formatted.
+    escape: bool
+        If true the text will be escaped
+
+    Returns
+    -------
+    NoEscape
+        The formatted string.
+
+    Examples
+    --------
+    >>> detokenize("file.pdf")
+    '\\detokenize{file.pdf}'
+    >>> print(detokenize("thisisa~1.pdf"))
+    \detokenize{thisisa~1.pdf}
+    """
+
+    if escape:
+        s = escape_latex(s)
+
+    return NoEscape(r'\detokenize{' + s + '}')
 
 def make_temp_dir():
     """Create a temporary directory if it doesn't exist.

--- a/tests/args.py
+++ b/tests/args.py
@@ -21,7 +21,7 @@ from pylatex import Document, Section, Math, Tabular, Figure, SubFigure, \
     SmallText, FootnoteText, TextColor, FBox, MdFramed, Tabu, \
     HorizontalSpace, VerticalSpace
 from pylatex.utils import escape_latex, fix_filename, dumps_list, bold, \
-    italic, verbatim, NoEscape
+    italic, verbatim, NoEscape, detokenize
 
 matplotlib.use('Agg')  # Not to use X server. For TravisCI.
 import matplotlib.pyplot as pyplot  # noqa

--- a/tests/args.py
+++ b/tests/args.py
@@ -166,6 +166,13 @@ def test_graphics():
         filename='', image_options=r"width=0.8\textwidth")
     repr(stand_alone_graphic)
 
+def test_stand_alone_graphic():
+    fname = "/just/a/test/file~1/path"
+
+    stand_alone_graphic = StandAloneGraphic(
+        filename=fname, image_options=r"width=0.8\textwidth")
+    repr(stand_alone_graphic)
+
 
 def test_quantities():
     # Quantities
@@ -328,6 +335,8 @@ def test_utils():
     italic(s='')
 
     verbatim(s='', delimiter='|')
+
+    detokenize(s='')
 
 
 def test_errors():


### PR DESCRIPTION
Added 'detokenize' to utils.py, follows same pattern as bold, verbatim, etc.

Added tilde check in StandAloneGraphic when referencing a file for windows tilde paths.
See: https://tex.stackexchange.com/questions/34918/how-to-use-tilde-or-space-in-includepdf-filename

Added test in args.py for StandAloneGraphic to be sure it can create a .tex string