### PR TITLE
Current working Directory

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -198,9 +198,9 @@ class Document(Environment):
         if basename == '':
             basename = 'default_basename'
 
-        os.chdir(dest_dir)
 
-        self.generate_tex(basename)
+
+        self.generate_tex(filepath)
 
         if compiler is not None:
             compilers = ((compiler, []),)
@@ -221,7 +221,7 @@ class Document(Environment):
 
             try:
                 output = subprocess.check_output(command,
-                                                 stderr=subprocess.STDOUT)
+                                                 stderr=subprocess.STDOUT,cwd=dest_dir)
             except (OSError, IOError) as e:
                 # Use FileNotFoundError when python 2 is dropped
                 os_error = e

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -141,12 +141,12 @@ class Document(Environment):
         str
         """
 
-        head = self.documentclass.dumps() + '%\n'
-        head += self.dumps_packages() + '%\n'
-        head += dumps_list(self.variables) + '%\n'
-        head += dumps_list(self.preamble) + '%\n'
+        head = self.documentclass.dumps() + '\n'
+        head += self.dumps_packages() + '\n'
+        head += dumps_list(self.variables) + '\n'
+        head += dumps_list(self.preamble) + '\n'
 
-        return head + '%\n' + super().dumps()
+        return head + '\n' + super().dumps()
 
     def generate_tex(self, filepath=None):
         """Generate a .tex file for the document.


### PR DESCRIPTION
The os.chdir in document.generate_pdf was causing me problems when generating pdfs concurrently (greenlet) using the subprocess option cwd=dest_dir fixes that for me.

Also, I am having trouble with the newly introduced "%\n" line endings so I removed it in my fork again. Cant say that I understand this issue though.