### PR TITLE
Alignat math environment

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,9 @@ Fixed
 - Allow mappers of `~.dumps_list` to return a `~.LatexObject`.
 - Section numbering default behaviour fixed
 - Setter method for `~.LatexObject.escape` property added
+- Escape and raw flags to `.Math` container
+- `.LatexObject._star_latex_name` flag to append a star
+- `.Alignat` environment that can contain strings and `.Math` containers
 
 1.1.1_ - `docs <../v1.1.1/>`__ - 2016-12-10
 -------------------------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,7 +21,7 @@ Fixed
 - Section numbering default behaviour fixed
 - Setter method for `~.LatexObject.escape` property added
 - Escape and raw flags to `.Math` container
-- `.LatexObject._star_latex_name` flag to append a star
+- ``_star_latex_name`` attribute of `.LatexObject` to append a star
 - `.Alignat` environment that can contain strings and `.Math` containers
 
 1.1.1_ - `docs <../v1.1.1/>`__ - 2016-12-10

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,9 +20,9 @@ Fixed
 - Allow mappers of `~.dumps_list` to return a `~.LatexObject`.
 - Section numbering default behaviour fixed
 - Setter method for `~.LatexObject.escape` property added
-- Escape and raw flags to `.Math` container
+- Escape flag to `.Math` container
 - ``_star_latex_name`` attribute of `.LatexObject` to append a star
-- `.Alignat` environment that can contain strings and `.Math` containers
+- `.Alignat` math environment
 
 1.1.1_ - `docs <../v1.1.1/>`__ - 2016-12-10
 -------------------------------------------

--- a/examples/full.py
+++ b/examples/full.py
@@ -13,7 +13,7 @@ and figures.
 import numpy as np
 
 from pylatex import Document, Section, Subsection, Tabular, Math, TikZ, Axis, \
-    Plot, Figure, Matrix
+    Plot, Figure, Matrix, Alignat
 from pylatex.utils import italic
 import os
 
@@ -47,9 +47,14 @@ if __name__ == '__main__':
         with doc.create(Subsection('Correct matrix equations')):
             doc.append(Math(data=[Matrix(M), Matrix(a), '=', Matrix(M * a)]))
 
+        with doc.create(Subsection('Alignat math environment')):
+            with doc.create(Alignat(numbering=False)) as agn:
+                agn.add_math(r'\frac{a}{b} &= 0 \\')
+                agn.add_math([Matrix(M), Matrix(a), '&=', Matrix(M * a)])
+
         with doc.create(Subsection('Beautiful graphs')):
             with doc.create(TikZ()):
-                plot_options = 'height=6cm, width=6cm, grid=major'
+                plot_options = 'height=4cm, width=6cm, grid=major'
                 with doc.create(Axis(options=plot_options)) as plot:
                     plot.append(Plot(name='model', func='-x^5 - 242'))
 

--- a/examples/full.py
+++ b/examples/full.py
@@ -48,9 +48,9 @@ if __name__ == '__main__':
             doc.append(Math(data=[Matrix(M), Matrix(a), '=', Matrix(M * a)]))
 
         with doc.create(Subsection('Alignat math environment')):
-            with doc.create(Alignat(numbering=False)) as agn:
-                agn.add_math(r'\frac{a}{b} &= 0 \\')
-                agn.add_math([Matrix(M), Matrix(a), '&=', Matrix(M * a)])
+            with doc.create(Alignat(numbering=False, escape=False)) as agn:
+                agn.append(r'\frac{a}{b} &= 0 \\')
+                agn.extend([Matrix(M), Matrix(a), '&=', Matrix(M * a)])
 
         with doc.create(Subsection('Beautiful graphs')):
             with doc.create(TikZ()):

--- a/pylatex/__init__.py
+++ b/pylatex/__init__.py
@@ -9,7 +9,7 @@ from .basic import HugeText, NewPage, LineBreak, NewLine, HFill, LargeText, \
     MediumText, SmallText, FootnoteText, TextColor
 from .document import Document
 from .frames import MdFramed, FBox
-from .math import Math, VectorName, Matrix
+from .math import Math, VectorName, Matrix, Alignat
 from .package import Package
 from .section import Section, Subsection, Subsubsection
 from .table import Table, MultiColumn, MultiRow, Tabular, Tabu, LongTable, \

--- a/pylatex/base_classes/latex_object.py
+++ b/pylatex/base_classes/latex_object.py
@@ -39,6 +39,7 @@ class LatexObject(metaclass=_CreatePackages):
     """
 
     _latex_name = None
+    _star_latex_name = False    # latex_name + ('*' if True else '')
 
     #: Set this to an iterable to override the list of default repr
     #: attributes.
@@ -126,9 +127,11 @@ class LatexObject(metaclass=_CreatePackages):
 
         It can be `None` when the class doesn't have a name.
         """
+        star = ('*' if self._star_latex_name else '')
         if self._latex_name is not None:
-            return self._latex_name
-        return self.__class__.__name__.lower()
+            return self._latex_name + star
+        else:
+            return self.__class__.__name__.lower() + star
 
     @latex_name.setter
     def latex_name(self, value):

--- a/pylatex/base_classes/latex_object.py
+++ b/pylatex/base_classes/latex_object.py
@@ -56,7 +56,7 @@ class LatexObject(metaclass=_CreatePackages):
 
     @property
     def escape(self):
-        """Determine wheter or not to escape content of this class.
+        """Determine whether or not to escape content of this class.
 
         This defaults to `True` for most classes.
         """

--- a/pylatex/base_classes/latex_object.py
+++ b/pylatex/base_classes/latex_object.py
@@ -130,8 +130,7 @@ class LatexObject(metaclass=_CreatePackages):
         star = ('*' if self._star_latex_name else '')
         if self._latex_name is not None:
             return self._latex_name + star
-        else:
-            return self.__class__.__name__.lower() + star
+        return self.__class__.__name__.lower() + star
 
     @latex_name.setter
     def latex_name(self, value):

--- a/pylatex/math.py
+++ b/pylatex/math.py
@@ -18,7 +18,7 @@ class Alignat(Environment):
     omit_if_empty = True
     packages = [Package('amsmath')]
 
-    def __init__(self, aligns=2, numbering=True, escape=False):
+    def __init__(self, aligns=2, numbering=True, escape=True):
         """
         Parameters
         ----------
@@ -34,24 +34,7 @@ class Alignat(Environment):
         self.escape = escape
         if not numbering:
             self._star_latex_name = True
-        super().__init__(
-            start_arguments=[str(int(aligns))]
-        )
-
-    def add_math(self, data, **kwargs):
-        """Add math to the list.
-
-        Args
-        ----
-        data: str, `~.LatexObject`, list[str, `~.LatexObject`]
-            The equation itself.
-        kwargs : dict
-            any keyword arguments to Math container
-        """
-        escape = kwargs.pop('escape', None) or self.escape
-        if not isinstance(data, (list, tuple)):
-            data = [data]
-        self.append(Math(data=list(data), raw=True, escape=escape, **kwargs))
+        super().__init__(start_arguments=[str(int(aligns))])
 
 
 class Math(Container):
@@ -61,8 +44,7 @@ class Math(Container):
 
     content_separator = ' '
 
-    def __init__(self, *, inline=False, data=None, raw=False,
-                 escape=False):
+    def __init__(self, *, inline=False, data=None, escape=True):
         r"""
         Args
         ----
@@ -70,14 +52,11 @@ class Math(Container):
             Content of the math container.
         inline: bool
             If the math should be displayed inline or not.
-        raw : bool
-            if raw, then will not be wrapped into environment
         escape : bool
             if True, will escape strings
         """
 
         self.inline = inline
-        self.raw = raw
         self.escape = escape
         super().__init__(data=data)
 
@@ -89,12 +68,9 @@ class Math(Container):
         str
 
         """
-        if self.raw:
-            return self.dumps_content()
-        elif self.inline:
+        if self.inline:
             return '$' + self.dumps_content() + '$'
-        else:
-            return '\\[%\n' + self.dumps_content() + '%\n\\]'
+        return '\\[%\n' + self.dumps_content() + '%\n\\]'
 
 
 class VectorName(Command):


### PR DESCRIPTION
Removed unrelated edits and all that is left is Alignat environment with changes that were needed to implement it or allow for its nice behavior.

Implemented:
* Implemented ```alignat ``` environment for aligned equations
* Added ```_star_latex_name``` for LatexObject - (Many environments and commands can use this)

Edited / fixed:
* Edited ```Math``` class so that it could act as raw math container without enclosing math brackets
* Edited ```Math``` class has arguments for LatexMathParser and NoEscape() map for strings
