### PR TITLE
Tabu tables learn 'spread' and 'to' syntax

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ This version might not be stable, but to install it use::
 
     pip install git+https://github.com/JelteF/PyLaTeX.git
 
+Changed
+~~~~~~~
+- Tabu and LongTabu environments learn 'spread' and 'to' syntax to control their width.
+
+
 Fixed
 ~~~~~
 - Escape ``[`` and ``]`` (left and right bracket).

--- a/examples/tabus.py
+++ b/examples/tabus.py
@@ -10,7 +10,7 @@ It creates a sample page filled with labels using the MiniPage element.
 
 # begin-doc-include
 from random import randint
-from pylatex import Document, LongTabu, HFill, Tabu, LineBreak, Center
+from pylatex import Document, LongTabu, Tabu, Center
 from pylatex.utils import bold
 
 
@@ -25,7 +25,8 @@ def genenerate_tabus():
     doc = Document(page_numbers=True, geometry_options=geometry_options)
 
     # Generate data table with 'tight' columns
-    with doc.create(LongTabu("X[r] X[r] X[r] X[r] X[r] X[r]", spread="0pt")) as data_table:
+    fmt = "X[r] X[r] X[r] X[r] X[r] X[r]"
+    with doc.create(LongTabu(fmt, spread="0pt")) as data_table:
         header_row1 = ["Prov", "Num", "CurBal", "IntPay", "Total", "IntR"]
         data_table.add_row(header_row1, mapper=[bold])
         data_table.add_hline()
@@ -42,7 +43,7 @@ def genenerate_tabus():
             header_row1 = ["X", "Y"]
             data_table.add_row(header_row1, mapper=[bold])
             data_table.add_hline()
-            row = [randint(0,1000), randint(0,1000)]
+            row = [randint(0, 1000), randint(0, 1000)]
             for i in range(4):
                 data_table.add_row(row)
 
@@ -51,10 +52,9 @@ def genenerate_tabus():
             header_row1 = ["X", "Y"]
             data_table.add_row(header_row1, mapper=[bold])
             data_table.add_hline()
-            row = [randint(0,1000), randint(0,1000)]
+            row = [randint(0, 1000), randint(0, 1000)]
             for i in range(4):
                 data_table.add_row(row)
-
 
     doc.generate_pdf("tabus", clean_tex=False)
 

--- a/examples/tabus.py
+++ b/examples/tabus.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+"""
+This example shows the functionality of the MiniPage element.
+
+It creates a sample page filled with labels using the MiniPage element.
+
+..  :copyright: (c) 2016 by Vladimir Gorovikov and Scott Wallace
+    :license: MIT, see License for more details.
+"""
+
+# begin-doc-include
+from random import randint
+from pylatex import Document, LongTabu, HFill, Tabu, LineBreak, Center
+from pylatex.utils import bold
+
+
+def genenerate_tabus():
+    geometry_options = {
+        "landscape": True,
+        "margin": "1.5in",
+        "headheight": "20pt",
+        "headsep": "10pt",
+        "includeheadfoot": True
+    }
+    doc = Document(page_numbers=True, geometry_options=geometry_options)
+
+    # Generate data table with 'tight' columns
+    with doc.create(LongTabu("X[r] X[r] X[r] X[r] X[r] X[r]", spread="0pt")) as data_table:
+        header_row1 = ["Prov", "Num", "CurBal", "IntPay", "Total", "IntR"]
+        data_table.add_row(header_row1, mapper=[bold])
+        data_table.add_hline()
+        data_table.add_empty_row()
+        data_table.end_table_header()
+        data_table.add_row(["Prov", "Num", "CurBal", "IntPay", "Total",
+                            "IntR"])
+        row = ["PA", "9", "$100", "%10", "$1000", "Test"]
+        for i in range(40):
+            data_table.add_row(row)
+
+    with doc.create(Center()) as centered:
+        with centered.create(Tabu("X[r] X[r]", spread="1in")) as data_table:
+            header_row1 = ["X", "Y"]
+            data_table.add_row(header_row1, mapper=[bold])
+            data_table.add_hline()
+            row = [randint(0,1000), randint(0,1000)]
+            for i in range(4):
+                data_table.add_row(row)
+
+    with doc.create(Center()) as centered:
+        with centered.create(Tabu("X[r] X[r]", to="4in")) as data_table:
+            header_row1 = ["X", "Y"]
+            data_table.add_row(header_row1, mapper=[bold])
+            data_table.add_hline()
+            row = [randint(0,1000), randint(0,1000)]
+            for i in range(4):
+                data_table.add_row(row)
+
+
+    doc.generate_pdf("tabus", clean_tex=False)
+
+genenerate_tabus()

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -377,7 +377,6 @@ class Tabu(Tabular):
 
     packages = [Package('tabu')]
 
-
     def __init__(self, table_spec, data=None, pos=None, *,
                  row_height=None, col_space=None, width=None, booktabs=None,
                  spread=None, to=None, **kwargs):
@@ -400,11 +399,11 @@ class Tabu(Tabular):
             configuration. This attribute is `False` by default.
         spread: str
             Specifies the Tabu table should add a given amount of 'padding' to
-            the width of the table. This should be a latex dimension; for example:
-            "0 pt" or "1in"
+            the width of the table. This should be a latex dimension;
+            for example: "0 pt" or "1in"
         to: str
-            Specifies the Tabu table should extend to a given width. This should be
-            a latex dimension; for example '4in'
+            Specifies the Tabu table should extend to a given width.
+            This should be a latex dimension; for example '4in'
         width: int
             The amount of columns that the table has. If this is `None` it is
             calculated based on the ``table_spec``, but this is only works for
@@ -416,8 +415,6 @@ class Tabu(Tabular):
         * https://en.wikibooks.org/wiki/LaTeX/Tables#The_tabular_environment
         """
 
-
-
         super().__init__(table_spec, data, pos,
                          row_height=row_height, col_space=col_space,
                          width=width, booktabs=booktabs, **kwargs)
@@ -426,10 +423,11 @@ class Tabu(Tabular):
         if spread:
             self._preamble = "spread " + spread
         elif to:
-            self._preamble = "to "+ to
-
+            self._preamble = "to " + to
 
     def dumps(self):
+        """Turn the tabu object into a string in Latex format."""
+
         _s = super().dumps()
 
         # Tabu tables support a unusual syntax:
@@ -444,7 +442,8 @@ class Tabu(Tabular):
             elif _s.startswith(r"\begin{tabu}"):
                 _s = _s[:12] + self._preamble + _s[12:]
             else:
-                raise TableError("Can't apply preamble '%s' to Tabu table (unexpected initial command sequence)"%self._preamble)
+                raise TableError("Can't apply preamble to Tabu table "
+                                 "(unexpected initial command sequence)")
 
         return _s
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -117,6 +117,14 @@ def test_table():
     coloredtable = Tabu(table_spec='X[c] X[c]')
     coloredtable.add_row(["test", "test2"], color="gray", mapper=bold)
 
+    # Colored Tabu with 'spread'
+    coloredtable = Tabu(table_spec='X[c] X[c]', spread="1in")
+    coloredtable.add_row(["test", "test2"], color="gray", mapper=bold)
+
+    # Colored Tabu with 'to'
+    coloredtable = Tabu(table_spec='X[c] X[c]', to="5in")
+    coloredtable.add_row(["test", "test2"], color="gray", mapper=bold)
+
     # Colored Tabularx
     coloredtable = Tabularx(table_spec='X[c] X[c]')
     coloredtable.add_row(["test", "test2"], color="gray", mapper=bold)


### PR DESCRIPTION
Tabu (and LongTabu) tables support an unusual Latex syntax for additional width control, these are now accessible to users of the Tabu/LongTabu classes through additional __init__ arguments

\begin{tabu} spread 0pt {...}

and 
\begin{tabu} to 5in {...}