### PR TITLE
Environment now respects 'content_separator'

### DIFF
--- a/examples/environment_ex.py
+++ b/examples/environment_ex.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""
+Wrapping existing LaTeX environments with the Environment class.
+
+..  :copyright: (c) 2014-2016 by Jelte Fennema, Scott Wallace
+    :license: MIT, see License for more details.
+"""
+
+# begin-doc-include
+from pylatex.base_classes import Environment
+from pylatex.package import Package
+from pylatex import Document, Section
+from pylatex.utils import NoEscape
+
+
+class AllTT(Environment):
+    """A class to wrap LaTeX's alltt environment."""
+
+    packages = [Package('alltt')]
+    escape = False
+    content_separator = "\n"
+
+# Create a new document
+doc = Document()
+with doc.create(Section('Wrapping Latex Environments')):
+    doc.append(NoEscape(
+        r"""
+        The following is a demonstration of a custom \LaTeX{}
+        command with a couple of parameters.
+        """))
+
+    # Put some data inside the AllTT environment
+    with doc.create(AllTT()):
+        verbatim = ("This is verbatim, alltt, text.\n\n\n"
+                    "Setting \\underline{escape} to \\underline{False} "
+                    "ensures that text in the environment is not\n"
+                    "subject to escaping...\n\n\n"
+                    "Setting \\underline{content_separator} "
+                    "ensures that line endings are broken in\n"
+                    "the latex just as they are in the input text.\n"
+                    "alltt supports math: \\(x^2=10\\)")
+        doc.append(verbatim)
+
+    doc.append("This is back to normal text...")
+
+# Generate pdf
+doc.generate_pdf('environment_ex', clean_tex=False)

--- a/pylatex/base_classes/containers.py
+++ b/pylatex/base_classes/containers.py
@@ -179,9 +179,9 @@ class Environment(Container):
         begin = Command('begin', self.start_arguments, self.options,
                         extra_arguments=extra_arguments)
         begin.arguments._positional_args.insert(0, self.latex_name)
-        string += begin.dumps() + '%\n'
+        string += begin.dumps() + self.content_separator
 
-        string += content + '%\n'
+        string += content + self.content_separator
 
         string += Command('end', self.latex_name).dumps()
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+
+"""Test to validate that Environments uphold contract of base classes."""
+
+from pylatex.base_classes import Environment
+
+
+def test_alltt():
+    class AllTT(Environment):
+        escape = False
+        content_separator = "\n"
+
+    alltt = AllTT()
+    alltt.append("This is alltt content\nIn two lines")
+    s = alltt.dumps()
+    assert s.startswith('\\begin{alltt}\nThis is'), \
+        "Unexpected start of environment"
+    assert s.endswith('two lines\n\\end{alltt}'), \
+        "Unexpected end of environment"


### PR DESCRIPTION
In master, the 'content_separator' is used to separate lines of text put into a container. But, this value is hardcoded into Environment.dumps().  This change simply removes the hard coded value ('%\n') and uses the value stored in 'content_seperator' as is done by the base class.