### PR TITLE
Make usage of inputenc and fontenc optional

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -41,9 +41,11 @@ class Document(Environment):
         document_options: str or `list`
             The options to supply to the documentclass
         fontenc: str
-            The option for the fontenc package.
+            The option for the fontenc package. If it is `None`, the fontenc
+            package will not be loaded at all.
         inputenc: str
-            The option for the inputenc package.
+            The option for the inputenc package. If it is `None`, the inputenc
+            package will not be loaded at all.
         font_size: str
             The font size to declare as normalsize
         lmodern: bool
@@ -83,10 +85,12 @@ class Document(Environment):
         self._indent = indent
         self._microtype = microtype
 
-        fontenc = Package('fontenc', options=fontenc)
-        inputenc = Package('inputenc', options=inputenc)
-        packages = [fontenc, inputenc]
+        packages = []
 
+        if fontenc is not None:
+            packages.append(Package('fontenc', options=fontenc))
+        if inputenc is not None:
+            packages.append(Package('inputenc', options=inputenc))
         if lmodern:
             packages.append(Package('lmodern'))
         if textcomp:

--- a/tests/test_no_fontenc.py
+++ b/tests/test_no_fontenc.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+r"""A test to make sure the document compiles with fontenc set to `None`."""
+
+from pylatex.base_classes import Arguments
+from pylatex import Document
+
+doc = Document('no_fontenc', fontenc=None)
+doc.append('test text')
+
+# Make sure fontenc isn't used
+assert not any([p.arguments == Arguments('fontenc') for p in doc.packages])
+
+doc.generate_pdf(clean=True, clean_tex=False, silent=False)

--- a/tests/test_no_inputenc.py
+++ b/tests/test_no_inputenc.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+r"""A test to make sure the document compiles with inputenc set to `None`."""
+
+from pylatex.base_classes import Arguments
+from pylatex import Document
+
+doc = Document('no_inputenc', inputenc=None)
+doc.append('test text')
+
+# Make sure inputenc isn't used
+assert not any([p.arguments == Arguments('inputenc') for p in doc.packages])
+
+doc.generate_pdf(clean=True, clean_tex=False, silent=False)


### PR DESCRIPTION
When using UTF-8 based engines, such as `xelatex` from XeTeX, you don't want to use `inputenc` and `fontenc`. With this change, it becomes possible to pass `None` for the `inputenc` and `fontenc` arguments to `Document` to avoid pulling in these packages.

There are no longer any warnings like

```
*** you should *not* be loading the inputenc package
*** XeTeX expects the source to be in UTF8 encoding
*** some features of other encodings may conflict, resulting in poor output.
```

when compiling with `xelatex` (provided you pass `None` for the arguments of course).

Fixes #170