### PR TITLE
Dont use os.chdir() in generate_pdf method, use cwd option of subpros…

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -202,9 +202,8 @@ class Document(Environment):
         if basename == '':
             basename = 'default_basename'
 
-        os.chdir(dest_dir)
 
-        self.generate_tex(basename)
+        self.generate_tex(os.path.join(dest_dir,basename))
 
         if compiler is not None:
             compilers = ((compiler, []),)
@@ -225,7 +224,8 @@ class Document(Environment):
 
             try:
                 output = subprocess.check_output(command,
-                                                 stderr=subprocess.STDOUT)
+                                                 stderr=subprocess.STDOUT,
+                                                 cwd=dest_dir)
             except (OSError, IOError) as e:
                 # Use FileNotFoundError when python 2 is dropped
                 os_error = e

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -195,7 +195,7 @@ class Document(Environment):
         filepath = self._select_filepath(filepath)
         filepath = os.path.join('.', filepath)
 
-        cur_dir = os.getcwd()
+
         dest_dir = os.path.dirname(filepath)
         basename = os.path.basename(filepath)
 
@@ -246,7 +246,7 @@ class Document(Environment):
                 try:
                     # Try latexmk cleaning first
                     subprocess.check_output(['latexmk', '-c', basename],
-                                            stderr=subprocess.STDOUT)
+                                            stderr=subprocess.STDOUT,cwd=dest_dir)
                 except (OSError, IOError, subprocess.CalledProcessError) as e:
                     # Otherwise just remove some file extensions.
                     extensions = ['aux', 'log', 'out', 'fls',
@@ -254,14 +254,14 @@ class Document(Environment):
 
                     for ext in extensions:
                         try:
-                            os.remove(basename + '.' + ext)
+                            os.remove(os.path.join(dest_dir,basename) + '.' + ext)
                         except (OSError, IOError) as e:
                             # Use FileNotFoundError when python 2 is dropped
                             if e.errno != errno.ENOENT:
                                 raise
 
             if clean_tex:
-                os.remove(basename + '.tex')  # Remove generated tex file
+                os.remove(os.path.join(dest_dir ,basename) + '.tex')  # Remove generated tex file
 
             rm_temp_dir()
 
@@ -273,7 +273,7 @@ class Document(Environment):
             # If none of the compilers worked, raise the last error
             raise(os_error)
 
-        os.chdir(cur_dir)
+
 
     def _select_filepath(self, filepath):
         """Make a choice between ``filepath`` and ``self.default_filepath``.


### PR DESCRIPTION
…ess instead.

This is important in multithreading, and Server processes.

The os.chdir() is a Problem when you use PyLatex, lets say, in a web app. Other parts of the code might depend on the current working directory too. If an exception happens during the pylatex compilation the current working directory can remain changed, and compromise the App.

For me, at least,  not using os.chdir fixted my problems and made PyLatex very reliable.