### PR TITLE
Adding label/ref support and use label in section.py

### DIFF
--- a/pylatex/__init__.py
+++ b/pylatex/__init__.py
@@ -26,6 +26,7 @@ from .errors import TableRowSizeError
 from .headfoot import PageStyle, Head, Foot, simple_page_number
 from .position import Center, FlushLeft, FlushRight, MiniPage, TextBlock, \
     HorizontalSpace, VerticalSpace
+from .labelref import Marker, Label, Ref, Pageref, Eqref, Autoref, Hyperref
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/pylatex/labelref.py
+++ b/pylatex/labelref.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""This module implements the label command and reference."""
+
+from .base_classes import CommandBase
+from .package import Package
+from .base_classes import LatexObject
+
+
+def remove_invalid_char(s):
+    """Remove invalid and dangerous characters from a string."""
+
+    s = ''.join([i if ord(i) >= 32 and ord(i) < 127 else '' for i in s])
+    s = s.translate(dict.fromkeys(map(ord, "_%~#\\{}\":")))
+    return s
+
+
+class Marker(LatexObject):
+    """A class that represents a marker (label/ref parameter)."""
+
+    _repr_attributes_override = [
+        'name',
+        'prefix',
+    ]
+
+    def __init__(self, name, prefix="", del_invalid_char=True):
+        """
+        Args
+        ----
+        name: str
+            Name of the marker.
+        prefix: str
+            Prefix to add before the name (prefix:name).
+        del_invalid_char: bool
+            If True invalid and dangerous characters will be
+            removed from the marker
+        """
+
+        if del_invalid_char:
+            prefix = remove_invalid_char(prefix)
+            name = remove_invalid_char(name)
+        self.prefix = prefix
+        self.name = name
+
+    def __str__(self):
+        return ((self.prefix + ":") if self.prefix != "" else "") + self.name
+
+    def dumps(self):
+        """Represent the Marker as a string in LaTeX syntax.
+
+        Returns
+        -------
+        str
+
+        """
+        return str(self)
+
+
+class RefLabelBase(CommandBase):
+    """A class used as base for command that take a marker only."""
+
+    _repr_attributes_mapping = {
+        'marker': 'arguments',
+    }
+
+    def __init__(self, marker):
+        """
+        Args
+        ----
+        marker: Marker
+            The marker to use with the label/ref.
+        """
+
+        self.marker = marker
+        super().__init__(arguments=(str(marker)))
+
+
+class Label(RefLabelBase):
+    """A class that represents a label."""
+
+
+class Ref(RefLabelBase):
+    """A class that represents a reference."""
+
+
+class Pageref(RefLabelBase):
+    """A class that represents a page reference."""
+
+
+class Eqref(RefLabelBase):
+    """A class that represent a ref to a formulae."""
+
+    packages = [Package('amsmath')]
+
+
+class Autoref(RefLabelBase):
+    """A class that represent an autoref."""
+
+    packages = [Package('hyperref')]
+
+
+class Hyperref(CommandBase):
+    """A class that represents an hyperlink to a label."""
+
+    _repr_attributes_mapping = {
+        'marker': 'options',
+        'text': 'arguments',
+    }
+
+    packages = [Package('hyperref')]
+
+    def __init__(self, marker, text):
+        """
+        Args
+        ----
+        marker: Marker
+            The marker to use with the label/ref.
+        text: str
+            The text that will be shown as a link
+            to the label of the same marker.
+        """
+
+        self.marker = marker
+        super().__init__(options=(str(marker)), arguments=text)

--- a/pylatex/labelref.py
+++ b/pylatex/labelref.py
@@ -6,7 +6,7 @@ from .package import Package
 from .base_classes import LatexObject
 
 
-def remove_invalid_char(s):
+def _remove_invalid_char(s):
     """Remove invalid and dangerous characters from a string."""
 
     s = ''.join([i if ord(i) >= 32 and ord(i) < 127 else '' for i in s])
@@ -36,8 +36,8 @@ class Marker(LatexObject):
         """
 
         if del_invalid_char:
-            prefix = remove_invalid_char(prefix)
-            name = remove_invalid_char(name)
+            prefix = _remove_invalid_char(prefix)
+            name = _remove_invalid_char(name)
         self.prefix = prefix
         self.name = name
 
@@ -90,6 +90,19 @@ class Eqref(RefLabelBase):
     """A class that represent a ref to a formulae."""
 
     packages = [Package('amsmath')]
+
+
+class Cref(RefLabelBase):
+    """A class that represent a cref (not a Cref)."""
+
+    packages = [Package('cleveref')]
+
+
+class CrefUp(RefLabelBase):
+    """A class that represent a Cref."""
+
+    packages = [Package('cleveref')]
+    latex_name = 'Cref'
 
 
 class Autoref(RefLabelBase):

--- a/pylatex/section.py
+++ b/pylatex/section.py
@@ -25,7 +25,7 @@ class Section(Container):
     #: subclasses will also have the new default.
     numbering = True
 
-    def __init__(self, title, numbering=None, label=True, **kwargs):
+    def __init__(self, title, numbering=None, *, label=True, **kwargs):
         """
         Args
         ----
@@ -33,7 +33,7 @@ class Section(Container):
             The section title.
         numbering: bool
             Add a number before the section title.
-        label: Label or bool
+        label: Label or bool or str
             Can set a label manually or use a boolean to set
             preference between automatic or no label
         """
@@ -44,6 +44,12 @@ class Section(Container):
             self.numbering = numbering
         if isinstance(label, Label):
             self.label = label
+        elif isinstance(label, str):
+            if ':' in label:
+                label = label.split(':', 1)
+                self.label = Label(Marker(label[1], label[0]))
+            else:
+                self.label = Label(Marker(label, self.marker_prefix))
         elif label:
             self.label = Label(Marker(title, self.marker_prefix))
         else:

--- a/pylatex/section.py
+++ b/pylatex/section.py
@@ -8,6 +8,7 @@ This module implements the section type classes.
 
 
 from .base_classes import Container, Command
+from .labelref import Marker, Label
 
 
 class Section(Container):
@@ -16,12 +17,15 @@ class Section(Container):
     #: A section should normally start in its own paragraph
     end_paragraph = True
 
+    #: Default prefix to use with Marker
+    marker_prefix = "sec"
+
     #: Number the sections when the section element is compatible,
     #: by changing the `~.Section` class default all
     #: subclasses will also have the new default.
     numbering = True
 
-    def __init__(self, title, numbering=None, **kwargs):
+    def __init__(self, title, numbering=None, label=True, **kwargs):
         """
         Args
         ----
@@ -29,12 +33,21 @@ class Section(Container):
             The section title.
         numbering: bool
             Add a number before the section title.
+        label: Label or bool
+            Can set a label manually or use a boolean to set
+            preference between automatic or no label
         """
 
         self.title = title
 
         if numbering is not None:
             self.numbering = numbering
+        if isinstance(label, Label):
+            self.label = label
+        elif label:
+            self.label = Label(Marker(title, self.marker_prefix))
+        else:
+            self.label = None
 
         super().__init__(**kwargs)
 
@@ -53,6 +66,8 @@ class Section(Container):
             num = ''
 
         string = Command(self.latex_name + num, self.title).dumps()
+        if self.label is not None:
+            string += '\n' + self.label.dumps()
         string += '%\n' + self.dumps_content()
 
         return string
@@ -61,22 +76,34 @@ class Section(Container):
 class Part(Section):
     """A class that represents a part."""
 
+    marker_prefix = "part"
+
 
 class Chapter(Section):
     """A class that represents a chapter."""
+
+    marker_prefix = "chap"
 
 
 class Subsection(Section):
     """A class that represents a subsection."""
 
+    marker_prefix = "subsec"
+
 
 class Subsubsection(Section):
     """A class that represents a subsubsection."""
+
+    marker_prefix = "ssubsec"
 
 
 class Paragraph(Section):
     """A class that represents a paragraph."""
 
+    marker_prefix = "para"
+
 
 class Subparagraph(Section):
     """A class that represents a subparagraph."""
+
+    marker_prefix = "subpara"

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -21,7 +21,7 @@ from pylatex import Document, Section, Math, Tabular, Figure, SubFigure, \
     SmallText, FootnoteText, TextColor, FBox, MdFramed, Tabu, \
     HorizontalSpace, VerticalSpace, TikZCoordinate, TikZNode, \
     TikZNodeAnchor, TikZUserPath, TikZPathList, TikZPath, TikZDraw, \
-    TikZScope, TikZOptions
+    TikZScope, TikZOptions, Hyperref, Marker
 from pylatex.utils import escape_latex, fix_filename, dumps_list, bold, \
     italic, verbatim, NoEscape
 
@@ -68,6 +68,11 @@ def test_document():
 def test_section():
     sec = Section(title='', numbering=True, data=None)
     repr(sec)
+
+
+def test_hyperref():
+    hr = Hyperref(Marker("marker", "prefix"), "text")
+    repr(hr)
 
 
 def test_math():


### PR DESCRIPTION
##  labelref.py/__init__.py/test_args.py: Add label/ref support

Add the support for label and multiple types of ref.
The new commands use a Marker object wich is the representation of the label/ref parameter in LaTeX.

## section.py: Add label support to sectioning classes

Add support for label in a way that let user choose between :
 - Specify his own Label
 - Automatic label (default)
 - No label

This way sections can be referenced using the marker in their label object.
