### PR TITLE
Add foot and last foot commands to longtables

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,10 @@ This version might not be stable, but to install it use::
 
     pip install git+https://github.com/JelteF/PyLaTeX.git
 
+Added
+~~~~~
+- Longtables now have end_foot() and end_last_foot() functions.
+
 1.2.1_ - `docs <../v1.2.1/>`__ - 2017-05-19
 -------------------------------------------
 

--- a/examples/longtable.py
+++ b/examples/longtable.py
@@ -24,17 +24,17 @@ def genenerate_longtabu():
             data_table.add_hline()
             data_table.add_row(["header 1", "header 2", "header 3"])
             data_table.add_hline()
-            data_table.end_head()
+            data_table.end_table_header()
             data_table.add_hline()
             data_table.add_row((MultiColumn(3, align='r',
                                 data='Containued on Next Page'),))
             data_table.add_hline()
-            data_table.end_foot()
+            data_table.end_table_footer()
             data_table.add_hline()
             data_table.add_row((MultiColumn(3, align='r',
                                 data='Not Containued on Next Page'),))
             data_table.add_hline()
-            data_table.end_last_foot()
+            data_table.end_table_last_footer()
             row = ["Content1", "9", "Longer String"]
             for i in range(150):
                 data_table.add_row(row)

--- a/examples/longtable.py
+++ b/examples/longtable.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+"""
+This example shows the functionality of the longtable element.
+
+It creates a sample multi-page spanning table
+
+..  :copyright: (c) 2017 by Jarrah Gosbell
+    :license: MIT, see License for more details.
+"""
+
+# begin-doc-include
+from pylatex import Document, LongTable, MultiColumn
+
+
+def genenerate_longtabu():
+    geometry_options = {
+        "margin": "2.54cm",
+        "includeheadfoot": True
+    }
+    doc = Document(page_numbers=True, geometry_options=geometry_options)
+
+    # Generate data table
+    with doc.create(LongTable("l l l")) as data_table:
+            data_table.add_hline()
+            data_table.add_row(["header 1", "header 2", "header 3"])
+            data_table.add_hline()
+            data_table.end_head()
+            data_table.add_hline()
+            data_table.add_row((MultiColumn(3, align='r',
+                                data='Containued on Next Page'),))
+            data_table.add_hline()
+            data_table.end_foot()
+            data_table.add_hline()
+            data_table.add_row((MultiColumn(3, align='r',
+                                data='Not Containued on Next Page'),))
+            data_table.add_hline()
+            data_table.end_last_foot()
+            row = ["Content1", "9", "Longer String"]
+            for i in range(150):
+                data_table.add_row(row)
+
+    doc.generate_pdf("longtable", clean_tex=False)
+
+genenerate_longtabu()

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -468,7 +468,7 @@ class LongTable(Tabular):
 
         self.append(Command(r'endhead'))
 
-    def end_foot(self):
+    def end_table_footer(self):
         r"""End the table foot which will appear on every page."""
 
         if self.foot:
@@ -479,7 +479,7 @@ class LongTable(Tabular):
 
         self.append(Command('endfoot'))
 
-    def end_last_foot(self):
+    def end_table_last_footer(self):
         r"""End the table foot which will appear on the last page."""
 
         if self.lastFoot:

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -454,6 +454,8 @@ class LongTable(Tabular):
     packages = [Package('longtable')]
 
     header = False
+    foot = False
+    lastFoot = False
 
     def end_table_header(self):
         r"""End the table header which will appear on every page."""
@@ -464,7 +466,29 @@ class LongTable(Tabular):
 
         self.header = True
 
-        self.append(NoEscape(r'\endhead'))
+        self.append(Command(r'endhead'))
+
+    def end_foot(self):
+        r"""End the table foot which will appear on every page."""
+
+        if self.foot:
+            msg = "Table already has a foot"
+            raise TableError(msg)
+
+        self.foot = True
+
+        self.append(Command(r'endfoot'))
+
+    def end_last_foot(self):
+        r"""End the table foot which will appear on the last page."""
+
+        if self.lastFoot:
+            msg = "Table already has a last foot"
+            raise TableError(msg)
+
+        self.lastFoot = True
+
+        self.append(Command(r'endlastfoot'))
 
 
 class LongTabu(LongTable, Tabu):

--- a/pylatex/table.py
+++ b/pylatex/table.py
@@ -477,7 +477,7 @@ class LongTable(Tabular):
 
         self.foot = True
 
-        self.append(Command(r'endfoot'))
+        self.append(Command('endfoot'))
 
     def end_last_foot(self):
         r"""End the table foot which will appear on the last page."""
@@ -488,7 +488,7 @@ class LongTable(Tabular):
 
         self.lastFoot = True
 
-        self.append(Command(r'endlastfoot'))
+        self.append(Command('endlastfoot'))
 
 
 class LongTabu(LongTable, Tabu):


### PR DESCRIPTION
Previously the "\endfoot" and "\endlastfoot" commands for longtables
had to be entered manually. This commit adds python function to use
these commands.

Add longtable foot commands to change log