### PR TITLE
Fix latex_name of Document class for inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/source/_static/examples
 docs/gh-pages
 
 coverage.xml
+
+# Folders
+.idea/
+.virtualenv/

--- a/examples/basic_inheritance.py
+++ b/examples/basic_inheritance.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+"""
+This example shows basic document generation functionality by inheritance.
+
+..  :copyright: (c) 2017 by Matthias Brandt.
+    :license: MIT, see License for more details.
+"""
+
+# begin-doc-include
+from pylatex import Document, Section, Subsection, Command
+from pylatex.utils import italic, NoEscape
+
+
+class MyDocument(Document):
+    def __init__(self):
+        super().__init__()
+
+        self.preamble.append(Command('title', 'Awesome Title'))
+        self.preamble.append(Command('author', 'Anonymous author'))
+        self.preamble.append(Command('date', NoEscape(r'\today')))
+        self.append(NoEscape(r'\maketitle'))
+
+    def fill_document(self):
+        """Add a section, a subsection and some text to the document."""
+        with self.create(Section('A section')):
+            self.append('Some regular text and some ')
+            self.append(italic('italic text. '))
+
+            with self.create(Subsection('A subsection')):
+                self.append('Also some crazy characters: $&#{}')
+
+
+if __name__ == '__main__':
+
+    # Document
+    doc = MyDocument()
+
+    # Call function to add text
+    doc.fill_document()
+
+    # Add stuff to the document
+    with doc.create(Section('A second section')):
+        doc.append('Some text.')
+
+    doc.generate_pdf('basic_inheritance', clean_tex=False)
+    tex = doc.dumps()  # The document as string in LaTeX syntax

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -108,6 +108,9 @@ class Document(Environment):
 
         super().__init__(data=data)
 
+        # Usually the name is the class name, but if we create our own document class, \begin{document} gets messed up.
+        self.latex_name = 'document'
+
         self.packages |= packages
         self.variables = []
 

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -108,7 +108,8 @@ class Document(Environment):
 
         super().__init__(data=data)
 
-        # Usually the name is the class name, but if we create our own document class, \begin{document} gets messed up.
+        # Usually the name is the class name, but if we create our own
+        # document class, \begin{document} gets messed up.
         self.latex_name = 'document'
 
         self.packages |= packages

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -5,11 +5,11 @@ from pylatex import Document
 
 class TestInheritance(unittest.TestCase):
 
-	def test_latex_name(self):
-		class MyDoc(Document):
-			def __init__(self):
-				super().__init__()
+    def test_latex_name(self):
+        class MyDoc(Document):
+            def __init__(self):
+                super().__init__()
 
-		doc = Document()
-		my_doc = MyDoc()
-		self.assertEqual(my_doc.latex_name, doc.latex_name)
+        doc = Document()
+        my_doc = MyDoc()
+        self.assertEqual(my_doc.latex_name, doc.latex_name)

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pylatex import Document
+
+
+class TestInheritance(unittest.TestCase):
+
+	def test_latex_name(self):
+		class MyDoc(Document):
+			def __init__(self):
+				super().__init__()
+
+		doc = Document()
+		my_doc = MyDoc()
+		self.assertEqual(my_doc.latex_name, doc.latex_name)


### PR DESCRIPTION
I used your package by inheriting from it (because it made sense to me) and stumbled onto an error. Because of the way the latex_name is implemented, the child class would start documents with

`\begin{mydocument}`

which obviously breaks pdflatex. This pull request hard codes latex_name for the document class to fix this problem. I’ve also added an example and a test case for inheritance.