### PR TITLE
Uncertain quantities fix

### DIFF
--- a/pylatex/quantities.py
+++ b/pylatex/quantities.py
@@ -82,7 +82,7 @@ class Quantity(Command):
             The quantity that should be displayed
         options: None, str, list or `~.Options`
             Options of the command. These are placed in front of the arguments.
-        format_cb: callableS
+        format_cb: callable
             A function which formats the number in the quantity. By default
             this uses `numpy.array_str`.
 

--- a/pylatex/quantities.py
+++ b/pylatex/quantities.py
@@ -69,8 +69,10 @@ def _dimensionality_to_siunitx(dim):
 class Quantity(Command):
     """A class representing quantities."""
 
-    packages = [Package('siunitx'),
-                NoEscape('\\DeclareSIUnit\\rpm{rpm}')]
+    packages = [
+        Package('siunitx', options=[NoEscape('separate-uncertainty=true')]),
+        NoEscape('\\DeclareSIUnit\\rpm{rpm}')
+    ]
 
     def __init__(self, quantity, *, options=None, format_cb=None):
         r"""
@@ -123,7 +125,8 @@ class Quantity(Command):
 
         if isinstance(quantity, pq.UncertainQuantity):
             magnitude_str = '{} +- {}'.format(
-                _format(quantity.magnitude), _format(quantity.uncertainty))
+                _format(quantity.magnitude),
+                _format(quantity.uncertainty.magnitude))
         elif isinstance(quantity, pq.Quantity):
             magnitude_str = _format(quantity.magnitude)
 

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -35,4 +35,5 @@ def test_dimensionality_to_siunitx():
 
 if __name__ == '__main__':
     test_quantity()
+    test_quantity_uncertain()
     test_dimensionality_to_siunitx()


### PR DESCRIPTION
`Quantity.dumps()` would include unit in uncertain quantity, e.g. `\SI{7.0 +- 1.0 s}{\second}` instead of `\SI{7.0 +- 1.0}{\second}`. Fixed and added `test_quantity_uncertain()` back to `test_quantities.py`.