### PR TITLE
TikZNode at fix

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,10 @@ This version might not be stable, but to install it use::
 
     pip install git+https://github.com/JelteF/PyLaTeX.git
 
+Fixed
+~~~~~
+- The 'at' parameter for TikZNode should now work.
+
 1.3.0_ - `docs <../v1.3.0/>`__ - 2017-05-19
 -------------------------------------------
 

--- a/examples/tikzdraw.py
+++ b/examples/tikzdraw.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
         # create our test node
         box = TikZNode(text='My block',
                        handle='box',
+                       at=TikZCoordinate(0, 0),
                        options=TikZOptions('draw',
                                            'rounded corners',
                                            **node_kwargs))

--- a/pylatex/tikz.py
+++ b/pylatex/tikz.py
@@ -237,7 +237,7 @@ class TikZNode(TikZObject):
             ret_str.append('({})'.format(self.handle))
 
         if self._node_position is not None:
-            ret_str.append('at {}'.format(str(self._position)))
+            ret_str.append('at {}'.format(str(self._node_position)))
 
         if self._node_text is not None:
             ret_str.append('{{{text}}};'.format(text=self._node_text))


### PR DESCRIPTION
I had issues compiling the latex for a document with a TikZNode with a specified 'at' location. I made a change that seemed logical but I don't fully understand how this could affect other things.