### PR TITLE
made temp path user-dependent

### DIFF
--- a/pylatex/utils.py
+++ b/pylatex/utils.py
@@ -7,6 +7,7 @@ This module implements some simple utility functions.
 """
 
 import os.path
+import getpass
 import shutil
 import tempfile
 import pylatex.base_classes
@@ -32,6 +33,7 @@ _latex_special_chars = {
 _tmp_path = os.path.abspath(
     os.path.join(
         tempfile.gettempdir(),
+        getpass.getuser(),
         "pylatex"
     )
 )


### PR DESCRIPTION
The temporary path currently is /tmp/pylatex in linux: https://github.com/JelteF/PyLaTeX/blob/62d9d9912ce8445e6629cdbcb80ad86143a1ed23/pylatex/utils.py#L32
and if multiple users are using pylatex, the 2nd user will get an error because the same directory was already created and owned by the first user. This PR fixed it by making the username a part of the temporary path. 