### PR TITLE
instead of chdir use the built in cwd of subprocess

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -199,13 +199,6 @@ class Document(Environment):
         if compiler_args is None:
             compiler_args = []
 
-        # Case 1: default_filepath = 'default_filepath', filepath = None ==> ./default_filepath.pdf
-        # Case 2: default_filepath = 'custom_value', filepath = None ==> ./custom_value.pdf
-        # Case 3: default_filepath = 'custom_value/', filepath = None ==> ./custom_value/default_basename.pdf
-        # Case 4: default_filepath = 'default_filepath', filepath = 'custom_value' ==> ./custom_value.pdf
-        # Case 5: default_filepath = 'default_filepath', filepath = 'custom_value/' ==> ./custom_value/default_filepath.pdf
-        # Case 6: default_filepath = 'custom_value/', filepath = 'custom_value/' ==> ./custom_value/custom_value/default_basename.pdf
-
         python_version = '{}.{}.{}'.format(sys.version_info[0],
                                            sys.version_info[1],
                                            sys.version_info[2])
@@ -256,7 +249,7 @@ class Document(Environment):
                 ('pdflatex', [])
             )
 
-        if python_cwd_available: 
+        if python_cwd_available:
             main_arguments = ['--interaction=nonstopmode', filepath + '.tex']
         else:
             main_arguments = ['--interaction=nonstopmode', basename + '.tex']
@@ -293,7 +286,8 @@ class Document(Environment):
                 try:
                     # Try latexmk cleaning first
                     if python_cwd_available:
-                        subprocess.check_output(['latexmk', '-c', filepath], cwd=dest_dir,
+                        subprocess.check_output(['latexmk', '-c', filepath],
+                                                cwd=dest_dir,
                                                 stderr=subprocess.STDOUT)
                     else:
                         subprocess.check_output(['latexmk', '-c', filepath],

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -16,7 +16,6 @@ from .package import Package
 from .errors import CompilerError
 from .utils import dumps_list, rm_temp_dir, NoEscape
 import pylatex.config as cf
-from packaging import version
 
 
 class Document(Environment):
@@ -199,12 +198,9 @@ class Document(Environment):
         if compiler_args is None:
             compiler_args = []
 
-        python_version = '{}.{}.{}'.format(sys.version_info[0],
-                                           sys.version_info[1],
-                                           sys.version_info[2])
         python_cwd_available = False
 
-        if version.parse(python_version) > version.parse("3.6"):
+        if sys.version_info >= (3, 6):
             # In case of newer python with the use of the cwd parameter
             # one can avoid to physically change the directory
             # to the destination folder

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -16,7 +16,6 @@ from .errors import CompilerError
 from .utils import dumps_list, rm_temp_dir, NoEscape
 import pylatex.config as cf
 
-
 class Document(Environment):
     r"""
     A class that contains a full LaTeX document.
@@ -199,6 +198,7 @@ class Document(Environment):
 
         filepath = self._select_filepath(filepath)
         filepath = os.path.join('.', filepath)
+        filepath = os.path.abspath(filepath)
 
         cur_dir = os.getcwd()
         dest_dir = os.path.dirname(filepath)
@@ -207,9 +207,7 @@ class Document(Environment):
         if basename == '':
             basename = 'default_basename'
 
-        os.chdir(dest_dir)
-
-        self.generate_tex(basename)
+        self.generate_tex(filepath)
 
         if compiler is not None:
             compilers = ((compiler, []),)
@@ -229,7 +227,7 @@ class Document(Environment):
             command = [compiler] + arguments + compiler_args + main_arguments
 
             try:
-                output = subprocess.check_output(command,
+                output = subprocess.check_output(command, cwd=dest_dir,
                                                  stderr=subprocess.STDOUT)
             except (OSError, IOError) as e:
                 # Use FileNotFoundError when python 2 is dropped
@@ -250,7 +248,7 @@ class Document(Environment):
             if clean:
                 try:
                     # Try latexmk cleaning first
-                    subprocess.check_output(['latexmk', '-c', basename],
+                    subprocess.check_output(['latexmk', '-c', basename], cwd=dest_dir,
                                             stderr=subprocess.STDOUT)
                 except (OSError, IOError, subprocess.CalledProcessError) as e:
                     # Otherwise just remove some file extensions.
@@ -281,7 +279,6 @@ class Document(Environment):
                 'or make sure you have latexmk or pdfLaTex installed.'
             ))
 
-        os.chdir(cur_dir)
 
     def _select_filepath(self, filepath):
         """Make a choice between ``filepath`` and ``self.default_filepath``.

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -327,7 +327,7 @@ class Document(Environment):
                 'or make sure you have latexmk or pdfLaTex installed.'
             ))
 
-        if python_cwd_available:
+        if not python_cwd_available:
             os.chdir(cur_dir)
 
     def _select_filepath(self, filepath):


### PR DESCRIPTION
This patch breaks compatibility with python 3.5 and lower. As Python2 is officially EOL and  Python 3.5 is soon going to be EOL as stated [here](https://devguide.python.org/#status-of-python-branches), imho this shouldn't be that big of a deal.

Of course I accept that if it is not going to be merged, as a lot of distros still provide python2 and python 3.5 as default, which would mean, that PyLaTeX is not going to be usable out of the box.

I'm convinced that this should fix #254, however I'm not an expert in threading, but I tried it with 5 concurrent threads with tempfile.TempDirectory() as output-dir, and it worked.