### PR TITLE
add example of installing LaTeX dependencies to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,11 @@ Simply install using ``pip``::
 
     pip install pylatex
 
+And then install a relevant LaTeX processor and other dependencies:
+
+    sudo apt-get install texlive-pictures texlive-science \
+    texlive-latex-extra imagemagick
+
 Documentation
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,12 @@ Simply install using ``pip``::
 
     pip install pylatex
 
-And then install a relevant LaTeX processor and other dependencies:
+And then install a relevant LaTeX processor and other dependencies. Examples:
 
+Ubuntu
+~~~~~~~
     sudo apt-get install texlive-pictures texlive-science \
-    texlive-latex-extra imagemagick
+    texlive-latex-extra latexmk
 
 Documentation
 -------------


### PR DESCRIPTION
There seems to have been several issues posted in relation to errors generated by missing packages, e.g. https://github.com/JelteF/PyLaTeX/issues/274.

Users should not have to find this information in the contributing guidelines or in previous issues. This request contains an example of dependency installation on Ubuntu.