### PR TITLE
Fixing bug in TikZNode class to enable specifying TikZCoordinate for node placement

### DIFF
--- a/pylatex/tikz.py
+++ b/pylatex/tikz.py
@@ -237,7 +237,7 @@ class TikZNode(TikZObject):
             ret_str.append('({})'.format(self.handle))
 
         if self._node_position is not None:
-            ret_str.append('at {}'.format(str(self._position)))
+            ret_str.append('at {}'.format(str(self._node_position)))
 
         if self._node_text is not None:
             ret_str.append('{{{text}}};'.format(text=self._node_text))


### PR DESCRIPTION
The "at" option in the TikZNode class is not working and making a minor change in line 240 in tikz.py seems to resolve the issue. I noticed a couple of older pull requests asking for the same change: https://github.com/JelteF/PyLaTeX/pull/232 & https://github.com/JelteF/PyLaTeX/pull/247. Can this be merged into master?