### PR TITLE
Improve whitespace handling in ContainerCommand

### DIFF
--- a/pylatex/base_classes/containers.py
+++ b/pylatex/base_classes/containers.py
@@ -233,10 +233,10 @@ class ContainerCommand(Container):
         start = Command(self.latex_name, arguments=self.arguments,
                         options=self.options)
 
-        string += start.dumps() + '{ \n'
+        string += start.dumps() + '{%\n'
 
         if content != '':
-            string += content + '\n}'
+            string += content + '%\n}'
         else:
             string += '}'
 


### PR DESCRIPTION
ContainerCommand added an extra space character to its output,
and it added newline characters without prefacing them with
a LaTeX percent sign (%) comment character.  These caused extra
whitespace in the output generated by LaTeX.  For many usages
that's okay, but when placing two containers next to one another
in a LaTeX document that can cause extra whitespace in the generated
PDF document, which is not necessarily desirable.  Issue #116 addressed
a similar problem.

This commit squashes the space character and adds two LaTeX comment
characters (%) to eliminate the undesirable whitespace.