### PR TITLE
Added ability to add extra packages to document

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -32,7 +32,7 @@ class Document(Environment):
                  documentclass='article', document_options=None, fontenc='T1',
                  inputenc='utf8', font_size="normalsize", lmodern=True,
                  textcomp=True, microtype=None, page_numbers=True, indent=None,
-                 geometry_options=None, data=None):
+                 geometry_options=None, data=None, **kwargs):
         r"""
         Args
         ----
@@ -106,6 +106,10 @@ class Document(Environment):
 
         if geometry_options is not None:
             packages.append(Package('geometry', options=geometry_options))
+
+        opt_packages = kwargs.get('packages', {})
+        for name, options in opt_packages.items():
+            packages.append(Package(name, options=options))
 
         super().__init__(data=data)
 


### PR DESCRIPTION
This commit allows you to set a variable number of additional packages to the document. For example, to work correctly with Russian language, you can set the babel package: 
`doc = Document(packages = {'babel': 'russian'}) `