### PR TITLE
geometry options bug

### DIFF
--- a/pylatex/base_classes/__init__.py
+++ b/pylatex/base_classes/__init__.py
@@ -8,7 +8,7 @@ Baseclasses that can be used to create classes representing LaTeX objects.
 from .latex_object import LatexObject
 from .containers import Container, Environment, ContainerCommand
 from .command import CommandBase, Command, UnsafeCommand, Options, \
-    SpecialOptions, Arguments
+    SpecialOptions, Arguments, SpecialArguments
 from .float import Float
 
 # Old names of the base classes for backwards compatibility

--- a/pylatex/base_classes/command.py
+++ b/pylatex/base_classes/command.py
@@ -376,3 +376,19 @@ class Arguments(Parameters):
         """
 
         return self._format_contents('{', '}{', '}')
+
+
+class SpecialArguments(Arguments):
+    """A class that separates arguments with ',' intsead of '}{'."""
+
+    def dumps(self):
+        """Represent the parameters as a string in LaTeX syntax.
+
+        This is to be appended to a command.
+
+        Returns
+        -------
+        str
+        """
+
+        return self._format_contents('{', ',', '}')

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -11,7 +11,7 @@ import sys
 import subprocess
 import errno
 from .base_classes import Environment, Command, Container, LatexObject, \
-    UnsafeCommand
+    UnsafeCommand, SpecialArguments
 from .package import Package
 from .errors import CompilerError
 from .utils import dumps_list, rm_temp_dir, NoEscape
@@ -108,7 +108,7 @@ class Document(Environment):
             packages.append(Package('geometry'))
             packages.append(Command(
                 'geometry',
-                arguments=','.join([k+'='+v for k,v in geometry_options.items()])
+                arguments=SpecialArguments(geometry_options),
             ))
 
         super().__init__(data=data)

--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -105,7 +105,11 @@ class Document(Environment):
             packages.append(Package('microtype'))
 
         if geometry_options is not None:
-            packages.append(Package('geometry', options=geometry_options))
+            packages.append(Package('geometry'))
+            packages.append(Command(
+                'geometry',
+                arguments=','.join([k+'='+v for k,v in geometry_options.items()])
+            ))
 
         super().__init__(data=data)
 


### PR DESCRIPTION
On a mac system, the previous method of setting up the geometry package led to errors.
With the proposed changes it works without problems.

For example, see discussion on https://tex.stackexchange.com/questions/412454/option-clash-for-package-geometry-reason