### PR TITLE
Allow TikZ plots to append options

### DIFF
--- a/pylatex/tikz.py
+++ b/pylatex/tikz.py
@@ -505,7 +505,8 @@ class Plot(LatexObject):
                  func=None,
                  coordinates=None,
                  error_bar=None,
-                 options=None):
+                 options=None,
+                 append_options=False):
         """
         Args
         ----
@@ -517,6 +518,9 @@ class Plot(LatexObject):
             A list of exact coordinates tat should be plotted.
 
         options: str, list or `~.Options`
+        append_options: bool
+            If the given options should be appended to the automatically
+            assigned TikZ cycle list.
         """
 
         self.name = name
@@ -524,6 +528,7 @@ class Plot(LatexObject):
         self.coordinates = coordinates
         self.error_bar = error_bar
         self.options = options
+        self.append_options = append_options
 
         super().__init__()
 
@@ -535,7 +540,14 @@ class Plot(LatexObject):
         str
         """
 
-        string = Command('addplot', options=self.options).dumps()
+        if not isinstance(self.append_options, bool):
+            raise TypeError(
+                'argument "append_options" can only be of type bool')
+        elif not self.append_options:
+            command_string = 'addplot'
+        else:
+            command_string = 'addplot+'
+        string = Command(command_string, options=self.options).dumps()
 
         if self.coordinates is not None:
             string += ' coordinates {%\n'

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -204,7 +204,7 @@ def test_tikz():
     repr(a)
 
     p = Plot(name=None, func=None, coordinates=None, error_bar=None,
-             options=None)
+             options=None, append_options=None)
     repr(p)
 
     opt = TikZOptions(None)


### PR DESCRIPTION
I added the keyword option `append_options` to the `Plot` class, which allows to optionally appended the given to the automatically assigned TikZ cycle list (via `\addplot+`, cf. [pgfplots manual](http://mirrors.ctan.org/graphics/pgf/contrib/pgfplots/doc/pgfplots.pdf) Section 3.3.2).

This is my first time contributing to this project, so please feel free to tell me if I missed something (eg. maybe this feature is already possible some other way) or got the workflow wrong.