### PR TITLE
docs: fix simple typo, intsead -> instead

### DIFF
--- a/pylatex/base_classes/command.py
+++ b/pylatex/base_classes/command.py
@@ -379,7 +379,7 @@ class Arguments(Parameters):
 
 
 class SpecialArguments(Arguments):
-    """A class that separates arguments with ',' intsead of '}{'."""
+    """A class that separates arguments with ',' instead of '}{'."""
 
     def dumps(self):
         """Represent the parameters as a string in LaTeX syntax.


### PR DESCRIPTION
There is a small typo in pylatex/base_classes/command.py.

Should read `instead` rather than `intsead`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md