### PR TITLE
Unit name for quantities only for a single character

### DIFF
--- a/pylatex/quantities.py
+++ b/pylatex/quantities.py
@@ -46,7 +46,7 @@ def _dimensionality_to_siunitx(dim):
             # Split unitname into prefix and actual name if possible
             if unit.name.startswith(prefix):
                 substring += '\\' + prefix
-                name = unit.name[len(prefix)]
+                name = unit.name[len(prefix):]
                 break
         else:
             # Otherwise simply use the full name


### PR DESCRIPTION
The actual version only works for single character names like N or A. For longer names like Hertz the result would only be H which leads to an error in latex (and is also wrong...).