### PR TITLE
Add option for replacing zeros in matrix with \cdot

### DIFF
--- a/pylatex/math.py
+++ b/pylatex/math.py
@@ -100,7 +100,7 @@ class Matrix(Environment):
         'alignment': 'arguments',
     }
 
-    def __init__(self, matrix, *, mtype='p', alignment=None):
+    def __init__(self, matrix, *, mtype='p', alignment=None, replace_zeros=False):
         r"""
         Args
         ----
@@ -113,6 +113,8 @@ class Matrix(Environment):
         alignment: str
             How to align the content of the cells in the matrix. This is ``c``
             by default.
+        replace_zeros: bool
+            Should zeros in the matrix be replaced with a cdot.
 
         References
         ----------
@@ -127,6 +129,7 @@ class Matrix(Environment):
         self._mtype = mtype
         if alignment is not None:
             self.latex_name += '*'
+        self._replace_zeros = replace_zeros
 
         super().__init__(arguments=alignment)
 
@@ -146,7 +149,7 @@ class Matrix(Environment):
         for (y, x), value in np.ndenumerate(self.matrix):
             if x:
                 string += '&'
-            string += str(value)
+            string += str(value) if not (value == 0 and self._replace_zeros) else '\cdot'
 
             if x == shape[1] - 1 and y != shape[0] - 1:
                 string += r'\\' + '%\n'


### PR DESCRIPTION
I've added an option to Martrix, which replaces zeros in the matrix with \cdot. This is used sometimes in mathematics and physics to make matricies which contian many zeros clearer.

![image](https://user-images.githubusercontent.com/51802274/200075508-d3b4fc76-5feb-4acd-8d45-ae78f4c2b468.png)

[Here](https://tex.stackexchange.com/questions/492436/how-do-i-partition-a-matrix-into-blocks-and-replace-zeros-with-dots) is someone else asking how to do in in LaTeX, justo to prove I'm not the only one who does this.

