### PR TITLE
fix: replace deprecated `np.matrix`

### DIFF
--- a/examples/full.py
+++ b/examples/full.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
                 table.add_row((4, 5, 6, 7))
 
     a = np.array([[100, 10, 20]]).T
-    M = np.matrix([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
+    M = np.array([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
 
     with doc.create(Section("The fancy stuff")):
         with doc.create(Subsection("Correct matrix equations")):

--- a/examples/numpy_ex.py
+++ b/examples/numpy_ex.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     section.append(subsection)
 
     subsection = Subsection("Matrix")
-    M = np.matrix([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
+    M = np.array([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
     matrix = Matrix(M, mtype="b")
     math = Math(data=["M=", matrix])
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -140,7 +140,7 @@ def test_math():
     repr(vec)
 
     # Numpy
-    m = np.matrix([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
+    m = np.array([[2, 3, 4], [0, 0, 1], [0, 0, 2]])
 
     matrix = Matrix(matrix=m, mtype="p", alignment=None)
     repr(matrix)


### PR DESCRIPTION
**PR Summary**:
This PR updates the code by replacing all instances of `np.matrix` with operations that treat the objects as arrays. The changes align with the recommendations mentioned in the [NumPy documentation](https://numpy.org/doc/stable/user/numpy-for-matlab-users.html#array-or-matrix-which-should-i-use). This modification ensures consistency and compatibility with modern coding practices and solves the following deprecation warning:
>   PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.

