### PR TITLE
Add examples/kitten.jpg to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.md
 recursive-include pylatex *.py
 recursive-include python2_source/pylatex *.py
 include versioneer.py
+include examples/kitten.jpg


### PR DESCRIPTION
The source tarball in PyPI contains tests but `tests/test_pictures.py` fails because it can't find `examples/kitten.jpg`. The file isn't contained in the tarball. This PR adds this file to the source tarball so the tests can be run successfully.

This is relevant when packaging PyLaTeX for distros. For instance, I'm packaging this for NixOS and the unit tests are run automatically when distro packages are built. Running the test suite as part of the distro package building is great and it would be nice if the tests worked properly.